### PR TITLE
Improve Matthew's Adventure image transitions

### DIFF
--- a/src/components/Sentence.tsx
+++ b/src/components/Sentence.tsx
@@ -1,7 +1,7 @@
 // import reactLogo from './assets/react.svg';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Assets } from '@/Game';
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 // import viteLogo from '/vite.svg';
 interface Sentence {
@@ -87,23 +87,29 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
   }, [isComplete]);
   return (
     <>
-      {assets &&
-        assetArray &&
-        assetArray.map((x, i, arr) => (
-          <Fragment key={i}>
-            {assets[x].audio && <audio src={assets[x].audio} autoPlay />}
-            {assets[x].image && (
-              <motion.img
-                className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-x-1/2 -translate-y-1/2 object-contain transition-all"
-                style={{ marginLeft: marginLeft(i, arr) }}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                src={assets[x].image}
-              />
+      {assets && assetArray && (
+        <>
+          {assetArray.map(
+            (x, i) => assets[x].audio && <audio key={`${x}-audio-${i}`} src={assets[x].audio} autoPlay />,
+          )}
+          <AnimatePresence>
+            {assetArray.map((x, i, arr) =>
+              assets[x].image ? (
+                <motion.img
+                  key={`${x}-image-${i}`}
+                  className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-x-1/2 -translate-y-1/2 object-contain transition-all"
+                  style={{ marginLeft: marginLeft(i, arr) }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.25, ease: 'easeOut' }}
+                  src={assets[x].image}
+                />
+              ) : null,
             )}
-          </Fragment>
-        ))}
+          </AnimatePresence>
+        </>
+      )}
       <p className="relative flex-auto whitespace-pre-line">
         {sentences}
         {isComplete ? (

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import Sentence, { SentenceProps } from '@/Sentence';
 import { getJson } from '#/getJson';
 import useDebounce from '#/useDebounce';
@@ -94,17 +95,35 @@ const Game = () => {
     <Preload assets={assetList}>
       <div onClick={nextScene} className="absolute inset-0">
         {place && assets[place]?.audio && <audio src={assets[place]?.audio} autoPlay />}
-        {character && (
-          <img
-            className="absolute bottom-0 z-10 w-1/2"
-            style={characterPosition}
-            src={assets[character]?.image}
-            alt={character}
-          />
-        )}
-        {place && assets[place]?.image && (
-          <img className="absolute h-full w-full object-cover" src={assets[place]?.image} alt={place} />
-        )}
+        <AnimatePresence mode="wait">
+          {character && assets[character]?.image && (
+            <motion.img
+              key={character}
+              className="absolute bottom-0 z-10 w-1/2"
+              style={characterPosition}
+              src={assets[character]?.image}
+              alt={character}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+            />
+          )}
+        </AnimatePresence>
+        <AnimatePresence mode="wait">
+          {place && assets[place]?.image && (
+            <motion.img
+              key={place}
+              className="absolute h-full w-full object-cover"
+              src={assets[place]?.image}
+              alt={place}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.45, ease: 'easeOut' }}
+            />
+          )}
+        </AnimatePresence>
         {sentence && (
           <div
             className="absolute inset-0 top-auto z-20 flex gap-2 border-t bg-white bg-opacity-75 p-2 text-black"


### PR DESCRIPTION
## Summary
- fade background and character art with framer-motion to avoid stuttering when scenes change
- wrap sentence asset rendering in AnimatePresence so CGs transition smoothly on mount/unmount

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68fac45e72408331b9c2adbf4537808f