### PR TITLE
Add chapter three dialogue script for Matthew’s Quest

### DIFF
--- a/public/assets3.json
+++ b/public/assets3.json
@@ -1,0 +1,38 @@
+{
+  "매튜": {
+    "image": "/assets/matthew.png"
+  },
+  "세라": {
+    "image": "/assets/sora.svg"
+  },
+  "루크": {
+    "image": "/assets/aria.svg"
+  },
+  "엘리": {
+    "image": "/assets/noah.svg"
+  },
+  "해리": {
+    "image": "/assets/programmer.jpg"
+  },
+  "그리드": {
+    "image": "/assets/grit-signal.svg"
+  },
+  "아메바 폐허": {
+    "image": "/assets/amoeba.jpg"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/code-lab.svg"
+  },
+  "업라이즈 시타델": {
+    "image": "/assets/uprise.jpg"
+  },
+  "한국일보 요새": {
+    "image": "/assets/history.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/strategy-room.svg"
+  },
+  "내면의 제단": {
+    "image": "/assets/matthew-home-garden.svg"
+  }
+}

--- a/public/chapter3.json
+++ b/public/chapter3.json
@@ -1,0 +1,609 @@
+[
+  {
+    "sentences": [
+      {
+        "message": "CHAPTER 1 — 잊혀진 코드의 나라"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "여긴… 어디지? 코드가… 살아 움직이고 있어?"
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "깨어났구나, 매튜. 네가 남긴 코드가 괴물이 되었어."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "내가 만든 코드가… 나를 공격하고 있다니."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "완벽함을 추구한 너의 집요함이 낳은 그림자야."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "그럼… 다시 정리해야지."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "시작하겠다는 건가?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "`Refactor Storm.` — 이제부터, 이 세상을 정리하겠어."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "아메바 폐허",
+    "sentences": [
+      {
+        "message": "네 손끝이 다시 불타는군. 하지만 잊지 마라, 불은 타오르면 사라진다."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "CHAPTER 2 — 세미티에스의 불꽃"
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "또 지각인가, 매튜? 팀이 너만 기다리고 있었어."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "죄송. 리빌드에 집중하느라 밤샜어."
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "또 화장실도 안 갔지? 인간 맞아?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "이번만은 완벽하게 세팅하고 싶었어."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "완벽주의자끼리 모이면 불이 나지."
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "불은 괜찮다. 문제는 협업이지."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "그럼 불을 하나로 묶자."
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "말은 멋지네. 방법은?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "`Monorepo Field.` — 모든 프로젝트를 하나의 불꽃으로."
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "세미티에스 공업도시",
+    "sentences": [
+      {
+        "message": "좋아. 그 불로 우리 길을 밝히자."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "CHAPTER 3 — 업라이즈의 그림자"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "이곳이… 암호화폐의 요새, 업라이즈 시타델인가."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "조심해. 여기선 버그도 디지털로 암호화돼 있어."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "이 도시엔 네 과거의 그림자가 잠들어 있다."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "Nuxt의 유령들… 스벨트킷의 힘으로 해방시켜야겠어."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "또 한 번 리팩토링이군. 넌 그걸 즐기나 봐."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "즐긴다기보단… 집착하지."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "그 집착이 널 강하게도, 약하게도 만든다."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "괜찮아. 집중이 깨질 때까진 멈추지 않아."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "그 말, 위험하게 들린다."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "업라이즈 시타델",
+    "sentences": [
+      {
+        "message": "괜찮아. 난 Grit이니까."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "CHAPTER 4 — 한국일보 요새의 기사"
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "매튜! 기사 데이터가 폭주하고 있어!"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "시스템 로그 보여줘."
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "서버가 3초마다 죽고 있어."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "좋아, 패턴이 보여."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "지금 그럴 여유 없어!"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "(눈 감으며) 집중모드로 들어간다. 누구도 건드리지 마."
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "또 화장실도 안 갈 거야?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "끝내고 간다."
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "이런 미친 집중력…"
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "네 불이 너무 밝다, 매튜. 타버릴 거야."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "괜찮아. 이 불로 요새를 구할 수 있다면."
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "기사 관리 시스템, 복구 완료!"
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "매튜, 넌 또 해냈군."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "한국일보 요새",
+    "sentences": [
+      {
+        "message": "(미소짓고) 아직은… 살아있네."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "CHAPTER 5 — 낭비 없는 왕국"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "이젠 알겠어. 완벽이 아니라 효율이야."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "네가 그 말을 하다니. 믿을 수가 없군."
+      }
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "‘짠돌이 왕국’이라더니 진짜 절약 모드야?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "낭비는 죄야. 시간도, 코드도, 체력도."
+      }
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "하지만 인간은 기계가 아니잖아."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "그래서 지금은… 분배를 배워야 해."
+      }
+    ]
+  },
+  {
+    "character": "엘리",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "드디어 네 안의 Grit이 균형을 찾는군."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "`Grit Engine.` — 불필요한 모든 걸 제거하고 본질만 남긴다."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "낭비 없는 왕국",
+    "sentences": [
+      {
+        "message": "잘했다, 매튜. 이제 진짜 완성형이 되었구나."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "FINAL CHAPTER — 그리드와의 대면"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "이제 마지막이군…"
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "그래. 이젠 나와 싸워야 한다."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "넌 내 일부야. 없애지 않아도 돼."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "그럼 왜 칼을 들었지?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "두려워서가 아니야. 확인하려고."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "네 불은 더 이상 타오르지 않는데?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "아니, 이젠 따뜻하게 빛나고 있어."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "…이게 균형이구나."
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "그래. 난 더 이상 나를 태우지 않아도 돼."
+      }
+    ]
+  },
+  {
+    "character": "그리드",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "그럼 네 모험은 끝난 건가?"
+      }
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "내면의 제단",
+    "sentences": [
+      {
+        "message": "아니, 이제 시작이야. 세상을 리팩토링할 차례지."
+      }
+    ]
+  },
+  {
+    "sentences": [
+      {
+        "message": "(조용히 화면이 어두워지며, 매튜의 엔진 소리만 들린다.)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a dedicated asset manifest for Matthew’s Quest dialogue characters and locations
- script the Matthew’s Quest visual novel dialogue for chapters 1 through the finale in chapter3.json

## Testing
- pnpm lint *(fails: existing lint errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68fc626280b48331ab185b8659302cfe