### PR TITLE
Rewrite visual novel chapters with limited assets

### DIFF
--- a/public/assets/emotion-determination.svg
+++ b/public/assets/emotion-determination.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="24" fill="#101321"/>
+  <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle" font-size="64">🔥⚙️</text>
+  <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="56">💪</text>
+</svg>

--- a/public/assets/emotion-hope.svg
+++ b/public/assets/emotion-hope.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="24" fill="#131c2a"/>
+  <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="60">🌅🚀</text>
+  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-size="52">🙂</text>
+</svg>

--- a/public/assets/emotion-relief.svg
+++ b/public/assets/emotion-relief.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="24" fill="#0f1d1a"/>
+  <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="60">🌿😌</text>
+  <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="54">✨</text>
+</svg>

--- a/public/assets/emotion-support.svg
+++ b/public/assets/emotion-support.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="24" fill="#111a2b"/>
+  <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="58">🤝😊</text>
+  <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="54">🌟</text>
+</svg>

--- a/public/assets/emotion-surprise.svg
+++ b/public/assets/emotion-surprise.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="24" fill="#1a1326"/>
+  <text x="50%" y="44%" dominant-baseline="middle" text-anchor="middle" font-size="60">⚡😲</text>
+  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-size="50">💬</text>
+</svg>

--- a/public/assets0.json
+++ b/public/assets0.json
@@ -1,98 +1,19 @@
 {
-  "별빛 기록관 엘리시아": {
-    "image": "/assets/character-elysia.svg"
-  },
-  "항로 설계사 매튜": {
-    "image": "/assets/matthew.png"
-  },
-  "시간 연금술사 이온": {
-    "image": "/assets/character-ion.svg"
-  },
-  "리액트 정령 노바": {
-    "image": "/assets/character-nova.svg"
-  },
-  "타입스크립트 비서관 루멘": {
-    "image": "/assets/character-lumen.svg"
-  },
-  "스타일 베틀 실피": {
-    "image": "/assets/character-sylphie.svg"
-  },
-  "길드 항해 지도": {
-    "image": "/assets/icon-guild-map.svg"
-  },
-  "guild-hall": {
-    "image": "/assets/bg-guild-hall.svg"
-  },
-  "starlit-archive": {
-    "image": "/assets/matthew-house.png"
-  },
-  "status-observatory": {
-    "image": "/assets/bg-status-observatory.svg"
-  },
-  "chronicle-deck": {
-    "image": "/assets/bg-chronicle-deck.svg"
-  },
-  "history": {
-    "image": "/assets/icon-history.svg"
-  },
-  "architecture": {
-    "image": "/assets/icon-architecture.svg"
-  },
-  "good": {
-    "image": "/assets/icon-good.svg"
-  },
-  "bad": {
-    "image": "/assets/icon-bad.svg"
-  },
-  "exclamation": {
-    "audio": "/assets/noti.wav"
-  },
-  "amoeba": {
-    "image": "/assets/icon-amoeba.svg"
-  },
-  "interpark": {
-    "image": "/assets/icon-interpark.svg"
-  },
-  "wisebirds": {
-    "image": "/assets/icon-wisebirds.svg"
-  },
-  "uprise": {
-    "image": "/assets/icon-uprise.svg"
-  },
-  "react": {
-    "image": "/assets/icon-react.svg"
-  },
-  "typescript": {
-    "image": "/assets/icon-typescript.svg"
-  },
-  "css": {
-    "image": "/assets/icon-css.svg"
-  },
-  "nuxt": {
-    "image": "/assets/icon-nuxt.svg"
-  },
-  "svelte": {
-    "image": "/assets/icon-svelte.svg"
-  },
-  "street": {
-    "image": "/assets/bg-street-night.svg"
-  },
-  "grit-signal": {
-    "image": "/assets/icon-grit.svg"
-  },
-  "momentum": {
-    "image": "/assets/icon-momentum.svg"
-  },
-  "conversation": {
-    "image": "/assets/icon-conversation.svg"
-  },
-  "innovation-hub": {
-    "image": "/assets/icon-innovation.svg"
-  },
-  "code-lab": {
-    "image": "/assets/icon-code-lab.svg"
-  },
-  "next": {
-    "image": "/assets/icon-next.svg"
-  }
+  "매튜": { "image": "/assets/character-matthew.png" },
+  "엘리": { "image": "/assets/character-elly.png" },
+  "그리드": { "image": "/assets/character-grid.png" },
+  "세라": { "image": "/assets/character-sera.png" },
+  "루크": { "image": "/assets/character-luke.png" },
+  "해리": { "image": "/assets/character-harry.png" },
+  "황혼 격납고": { "image": "/assets/bg-1.png" },
+  "나선 도서관": { "image": "/assets/bg-2.png" },
+  "신호 교차로": { "image": "/assets/bg-3.png" },
+  "공명 실험실": { "image": "/assets/bg-4.png" },
+  "공중 정원": { "image": "/assets/bg-5.png" },
+  "별빛 강당": { "image": "/assets/bg-6.png" },
+  "emotion-determination": { "image": "/assets/emotion-determination.svg" },
+  "emotion-relief": { "image": "/assets/emotion-relief.svg" },
+  "emotion-surprise": { "image": "/assets/emotion-surprise.svg" },
+  "emotion-support": { "image": "/assets/emotion-support.svg" },
+  "emotion-hope": { "image": "/assets/emotion-hope.svg" }
 }

--- a/public/assets1.json
+++ b/public/assets1.json
@@ -1,86 +1,19 @@
 {
-  "matthew": {
-    "image": "/assets/matthew.png"
-  },
-  "매튜 전략가": {
-    "image": "/assets/matthew.png"
-  },
-  "매튜 탐험가": {
-    "image": "/assets/matthew.png"
-  },
-  "매튜 멘토": {
-    "image": "/assets/matthew.png"
-  },
-  "street": {
-    "image": "/assets/bg-street-night.svg"
-  },
-  "thumbs": {
-    "image": "/assets/icon-thumbs.svg"
-  },
-  "conversation": {
-    "image": "/assets/icon-conversation.svg"
-  },
-  "noti": {
-    "audio": "/assets/noti.wav"
-  },
-  "programmer": {
-    "image": "/assets/icon-programmer.svg"
-  },
-  "developer": {
-    "image": "/assets/bg-developer-studio.svg"
-  },
-  "innovation-hub": {
-    "image": "/assets/icon-innovation.svg"
-  },
-  "strategy-room": {
-    "image": "/assets/bg-matthew-strategy.svg"
-  },
-  "code-lab": {
-    "image": "/assets/icon-code-lab.svg"
-  },
-  "matthew-home-lab": {
-    "image": "/assets/bg-matthew-lab.svg"
-  },
-  "matthew-home-strategy": {
-    "image": "/assets/bg-matthew-strategy.svg"
-  },
-  "matthew-home-garden": {
-    "image": "/assets/bg-matthew-garden.svg"
-  },
-  "grit-signal": {
-    "image": "/assets/icon-grit.svg"
-  },
-  "momentum": {
-    "image": "/assets/icon-momentum.svg"
-  },
-  "emoji-focus": {
-    "image": "/assets/icon-focus.svg"
-  },
-  "emoji-relief": {
-    "image": "/assets/icon-relief.svg"
-  },
-  "emoji-joy": {
-    "image": "/assets/icon-joy.svg"
-  },
-  "emoji-steady": {
-    "image": "/assets/icon-steady.svg"
-  },
-  "aria": {
-    "image": "/assets/character-aria.svg"
-  },
-  "noah": {
-    "image": "/assets/character-noah.svg"
-  },
-  "sora": {
-    "image": "/assets/character-sora.svg"
-  },
-  "history": {
-    "image": "/assets/icon-history.svg"
-  },
-  "kongju": {
-    "image": "/assets/icon-kongju.svg"
-  },
-  "now": {
-    "image": "/assets/bg-now-studio.svg"
-  }
+  "매튜": { "image": "/assets/character-matthew.png" },
+  "엘리": { "image": "/assets/character-elly.png" },
+  "그리드": { "image": "/assets/character-grid.png" },
+  "세라": { "image": "/assets/character-sera.png" },
+  "루크": { "image": "/assets/character-luke.png" },
+  "해리": { "image": "/assets/character-harry.png" },
+  "황혼 격납고": { "image": "/assets/bg-1.png" },
+  "나선 도서관": { "image": "/assets/bg-2.png" },
+  "신호 교차로": { "image": "/assets/bg-3.png" },
+  "공명 실험실": { "image": "/assets/bg-4.png" },
+  "공중 정원": { "image": "/assets/bg-5.png" },
+  "별빛 강당": { "image": "/assets/bg-6.png" },
+  "emotion-determination": { "image": "/assets/emotion-determination.svg" },
+  "emotion-relief": { "image": "/assets/emotion-relief.svg" },
+  "emotion-surprise": { "image": "/assets/emotion-surprise.svg" },
+  "emotion-support": { "image": "/assets/emotion-support.svg" },
+  "emotion-hope": { "image": "/assets/emotion-hope.svg" }
 }

--- a/public/assets2.json
+++ b/public/assets2.json
@@ -1,35 +1,19 @@
 {
-  "matthew": {
-    "image": "/assets/matthew.png"
-  },
-  "developer": {
-    "image": "/assets/bg-developer-studio.svg"
-  },
-  "conversation": {
-    "image": "/assets/bg-conversation-lounge.svg"
-  },
-  "now": {
-    "image": "/assets/bg-now-studio.svg"
-  },
-  "street": {
-    "image": "/assets/bg-street-night.svg"
-  },
-  "thumbs": {
-    "image": "/assets/icon-thumbs.svg"
-  },
-  "react": {
-    "image": "/assets/icon-react.svg"
-  },
-  "next": {
-    "image": "/assets/icon-next.svg"
-  },
-  "svelte": {
-    "image": "/assets/icon-svelte.svg"
-  },
-  "nuxt": {
-    "image": "/assets/icon-nuxt.svg"
-  },
-  "noti": {
-    "audio": "/assets/noti.wav"
-  }
+  "매튜": { "image": "/assets/character-matthew.png" },
+  "엘리": { "image": "/assets/character-elly.png" },
+  "그리드": { "image": "/assets/character-grid.png" },
+  "세라": { "image": "/assets/character-sera.png" },
+  "루크": { "image": "/assets/character-luke.png" },
+  "해리": { "image": "/assets/character-harry.png" },
+  "황혼 격납고": { "image": "/assets/bg-1.png" },
+  "나선 도서관": { "image": "/assets/bg-2.png" },
+  "신호 교차로": { "image": "/assets/bg-3.png" },
+  "공명 실험실": { "image": "/assets/bg-4.png" },
+  "공중 정원": { "image": "/assets/bg-5.png" },
+  "별빛 강당": { "image": "/assets/bg-6.png" },
+  "emotion-determination": { "image": "/assets/emotion-determination.svg" },
+  "emotion-relief": { "image": "/assets/emotion-relief.svg" },
+  "emotion-surprise": { "image": "/assets/emotion-surprise.svg" },
+  "emotion-support": { "image": "/assets/emotion-support.svg" },
+  "emotion-hope": { "image": "/assets/emotion-hope.svg" }
 }

--- a/public/assets3.json
+++ b/public/assets3.json
@@ -1,38 +1,19 @@
 {
-  "매튜": {
-    "image": "/assets/matthew.png"
-  },
-  "세라": {
-    "image": "/assets/character-sera.svg"
-  },
-  "루크": {
-    "image": "/assets/character-luke.svg"
-  },
-  "엘리": {
-    "image": "/assets/character-elly.svg"
-  },
-  "해리": {
-    "image": "/assets/character-harry.svg"
-  },
-  "그리드": {
-    "image": "/assets/character-grid.svg"
-  },
-  "아메바 폐허": {
-    "image": "/assets/bg-amoeba-ruins.svg"
-  },
-  "세미티에스 공업도시": {
-    "image": "/assets/bg-industrial-city.svg"
-  },
-  "업라이즈 시타델": {
-    "image": "/assets/bg-uprise-citadel.svg"
-  },
-  "한국일보 요새": {
-    "image": "/assets/bg-korea-fortress.svg"
-  },
-  "낭비 없는 왕국": {
-    "image": "/assets/bg-efficient-kingdom.svg"
-  },
-  "내면의 제단": {
-    "image": "/assets/bg-inner-sanctum.svg"
-  }
+  "매튜": { "image": "/assets/character-matthew.png" },
+  "엘리": { "image": "/assets/character-elly.png" },
+  "그리드": { "image": "/assets/character-grid.png" },
+  "세라": { "image": "/assets/character-sera.png" },
+  "루크": { "image": "/assets/character-luke.png" },
+  "해리": { "image": "/assets/character-harry.png" },
+  "황혼 격납고": { "image": "/assets/bg-1.png" },
+  "나선 도서관": { "image": "/assets/bg-2.png" },
+  "신호 교차로": { "image": "/assets/bg-3.png" },
+  "공명 실험실": { "image": "/assets/bg-4.png" },
+  "공중 정원": { "image": "/assets/bg-5.png" },
+  "별빛 강당": { "image": "/assets/bg-6.png" },
+  "emotion-determination": { "image": "/assets/emotion-determination.svg" },
+  "emotion-relief": { "image": "/assets/emotion-relief.svg" },
+  "emotion-surprise": { "image": "/assets/emotion-surprise.svg" },
+  "emotion-support": { "image": "/assets/emotion-support.svg" },
+  "emotion-hope": { "image": "/assets/emotion-hope.svg" }
 }

--- a/public/chapter0.json
+++ b/public/chapter0.json
@@ -1,403 +1,73 @@
 [
   {
+    "character": "매튜",
+    "place": "황혼 격납고",
     "sentences": [
       [
-        {
-          "message": "화면을 터치하면 연대기가 흘러갑니다.",
-          "duration": 200
-        }
+        { "message": "엘리, 네가 불러낸 새 임무가 바로 이 격납고인가?" }
       ],
       [
-        {
-          "message": "별빛 기록관이 서사를 펼칠 준비를 마쳤습니다.",
-          "duration": 220
-        }
+        { "message": "도시 전체를 덮은 오래된 빌드 냄새가 다시 피어오르는군." }
       ]
     ]
   },
   {
-    "character": "별빛 기록관 엘리시아",
-    "place": "starlit-archive",
+    "character": "엘리",
+    "place": "황혼 격납고",
     "sentences": [
       [
-        {
-          "message": "은하수처럼 빛나는 서고에 잔잔한 목소리가 울립니다.",
-          "duration": 220
-        }
+        { "message": "그래, 매튜. 이곳에서 모든 노선이 꼬여 버렸어." }
       ],
       [
-        {
-          "message": "\"환영합니다, 새벽 길드의 신화 기록을 열람하러 오셨군요.\"",
-          "duration": 220,
-          "asset": "exclamation"
-        }
-      ],
-      [
-        {
-          "message": "오늘은 항로 설계사 매튜의 연대기를 펼쳐 보려 합니다.",
-          "duration": 220
-        }
+        { "message": "한 번 더 처음부터 짜야 해. 이번엔 완전히." }
       ]
     ]
   },
   {
-    "character": "항로 설계사 매튜",
-    "place": "starlit-archive",
+    "character": "매튜",
+    "place": "황혼 격납고",
     "sentences": [
       [
-        {
-          "message": "안녕하세요.",
-          "duration": 200
-        }
+        { "message": "좋아. 초점은 명확해. 팀 전원의 동선을 재부팅하지." }
       ],
       [
-        {
-          "message": "저는",
-          "duration": 200
-        },
-        {
-          "message": " 건축학",
-          "asset": "architecture"
-        },
-        {
-          "message": "을 탐험하던 시절을 지나",
-          "duration": 220
-        },
-        {
-          "message": " 코드로 항로를 짜는 설계사 매튜입니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "도면의 기억은 흐릿하지만",
-          "duration": 220
-        },
-        {
-          "message": " 일정과 협업의 맥박만큼은",
-          "asset": "momentum"
-        },
-        {
-          "message": " 지금도 선명합니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "콘크리트 대신 코드로 구조를 지으며",
-          "duration": 220
-        },
-        {
-          "message": " 팀이 시간 안에 도착하도록 길을 냅니다.",
-          "duration": 220,
-          "asset": "good"
-        }
+        { "message": "모든 감각을 하나로 묶는다.", "asset": "emotion-determination" }
       ]
     ]
   },
   {
-    "character": "시간 연금술사 이온",
-    "place": "status-observatory",
+    "character": "그리드",
+    "place": "황혼 격납고",
     "sentences": [
       [
-        {
-          "message": "팅! 매튜의 현 레벨은",
-          "duration": 200
-        },
-        {
-          "message": " 47",
-          "asset": "momentum"
-        },
-        {
-          "message": ". 집중력과 실행력의 궤도가 맞물려 있습니다.",
-          "duration": 220
-        }
+        { "message": "재부팅이라… 네가 태웠던 불씨를 다시 부르겠다는 뜻이지?" }
       ],
       [
-        {
-          "message": "새벽 러닝으로 다져진 체력은",
-          "duration": 220
-        },
-        {
-          "message": " 강인한 근성",
-          "asset": "grit-signal"
-        },
-        {
-          "message": "으로 안정적으로 빛나고 있군요.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "시간표를 조율하는 능력은 길드에서도 손꼽힙니다.",
-          "duration": 220
-        }
+        { "message": "이번엔 완전히 태우고 사라지지 않게 해 봐." }
       ]
     ]
   },
   {
-    "character": "리액트 정령 노바",
-    "place": "status-observatory",
+    "character": "엘리",
+    "place": "나선 도서관",
     "sentences": [
       [
-        {
-          "message": "나는 매튜의 주력 기술,",
-          "duration": 220
-        },
-        {
-          "message": " 리액트",
-          "asset": "react"
-        },
-        {
-          "message": "를 형상화한 정령 노바.",
-          "duration": 220
-        }
+        { "message": "자료실을 새로 정리해 뒀어." }
       ],
       [
-        {
-          "message": "컴포넌트를 조합하고 상태를 전투처럼 다루는 솜씨는 이미 S랭크.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "새로운 UI 던전이 열리면 내가 먼저 발광할 거야.",
-          "duration": 220
-        }
+        { "message": "각 배경과 장비는 여섯 개뿐. 우린 그 안에서 다시 세계를 만들어야 해." }
       ]
     ]
   },
   {
-    "character": "타입스크립트 비서관 루멘",
-    "place": "status-observatory",
+    "character": "매튜",
+    "place": "나선 도서관",
     "sentences": [
       [
-        {
-          "message": "페이지마다 안전을 더하는 매튜의 숙련도,",
-          "duration": 220
-        },
-        {
-          "message": " 타입스크립트",
-          "asset": "typescript"
-        },
-        {
-          "message": " 비서관 루멘이 보증합니다.",
-          "duration": 220
-        }
+        { "message": "제약이 곧 설계의 라인이지." }
       ],
       [
-        {
-          "message": "강력한 타입은 협업자들에게도 안심할 수 있는 방패가 되죠.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "루틴한 업무도 제너릭과 유틸 함수로 경량화했습니다.",
-          "duration": 220
-        }
-      ]
-    ]
-  },
-  {
-    "character": "스타일 베틀 실피",
-    "place": "status-observatory",
-    "sentences": [
-      [
-        {
-          "message": "부드러운 인터랙션과 반짝이는 레이아웃은",
-          "duration": 220
-        },
-        {
-          "message": " CSS",
-          "asset": "css"
-        },
-        {
-          "message": " 베틀 실피가 직조한 예술.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "Tailwind, Sass, 순정 CSS까지 다양한 무늬를 즉시 꺼내 보입니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "매튜가 상상한 인터페이스는 내 실타래를 통해 현실이 됩니다.",
-          "duration": 220
-        }
-      ]
-    ]
-  },
-  {
-    "character": "길드 항해 지도",
-    "place": "chronicle-deck",
-    "sentences": [
-      [
-        {
-          "message": "첫 항해지는",
-          "duration": 220
-        },
-        {
-          "message": " 아메바 웹에이전시",
-          "asset": "amoeba"
-        },
-        {
-          "message": "였습니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "디멘딩한 파도 속에서도 새벽 출항을 습관으로 만들어 시간을 확보했죠.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "다음은",
-          "duration": 220
-        },
-        {
-          "message": " 인터파크 요새",
-          "asset": "interpark"
-        },
-        {
-          "message": "에서 UI를 새로 배치했습니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "돔의 수와 퍼포먼스 사이 관계를 끝없이 탐색한 연구 기록이 남아 있습니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "와이즈버즈 항구에서는",
-          "duration": 220
-        },
-        {
-          "message": " 팀 전체가 사용하는",
-          "duration": 220
-        },
-        {
-          "message": " 크롬 확장 도구",
-          "asset": "conversation"
-        },
-        {
-          "message": "를 개항하고",
-          "duration": 220
-        },
-        {
-          "message": " 타입스크립트",
-          "asset": "typescript"
-        },
-        {
-          "message": " 도입을 주도했습니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "업라이즈 공중성채에서는",
-          "duration": 220
-        },
-        {
-          "message": " Nuxt",
-          "asset": "nuxt"
-        },
-        {
-          "message": "에서",
-          "duration": 220
-        },
-        {
-          "message": " SvelteKit",
-          "asset": "svelte"
-        },
-        {
-          "message": "으로 포팅하며 아키텍처 감각을 확장했지요.",
-          "duration": 220
-        }
-      ]
-    ]
-  },
-  {
-    "character": "항로 설계사 매튜",
-    "place": "guild-hall",
-    "sentences": [
-      [
-        {
-          "message": "지금 나는 길드의 새벽 창가에서 다음 항해 지도를 펼칩니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "동료가 필요한 현장에는",
-          "duration": 220
-        },
-        {
-          "message": " 협업",
-          "asset": "conversation"
-        },
-        {
-          "message": "의 불꽃을,",
-          "duration": 220
-        },
-        {
-          "message": " 새로운 시장에는",
-          "duration": 220
-        },
-        {
-          "message": " 창의력",
-          "asset": "innovation-hub"
-        },
-        {
-          "message": "의 빛을 비출 겁니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "길드는 아직 쓰이지 않은 항해지를 가득 품고 있으니까요.",
-          "duration": 220
-        }
-      ]
-    ]
-  },
-  {
-    "character": "별빛 기록관 엘리시아",
-    "place": "starlit-archive",
-    "sentences": [
-      [
-        {
-          "message": "연대기의 마지막 페이지를 덮으며 그녀가 속삭입니다.",
-          "duration": 220
-        }
-      ],
-      [
-        {
-          "message": "\"이 기록은 계속해서 쓰일 예정입니다. 다음 장에서 다시 만나요.\"",
-          "duration": 220
-        }
-      ]
-    ]
-  },
-  {
-    "sentences": [
-      [
-        {
-          "message": "매튜의 기록은 아직 진행 중입니다.\\n",
-          "duration": 220
-        },
-        {
-          "message": "다음 챕터에서 새 모험이 이어집니다.",
-          "asset": "next"
-        }
+        { "message": "여섯 개의 공간으로 여섯 장의 궤도를 그려 보자.", "asset": "emotion-hope" }
       ]
     ]
   }

--- a/public/chapter1.json
+++ b/public/chapter1.json
@@ -1,121 +1,78 @@
 [
   {
     "sentences": [
-      [
-        {
-          "message": "챕터 1 : 매튜의 집요한 모험은 다시 집에서 시작됩니다."
-        },
-        {
-          "message": "오늘도 저는 전략 노트를 펴고 마음을 가다듬습니다.",
-          "asset": "emoji-steady"
-        }
-      ]
+      [ { "message": "CHAPTER 1 — 신호를 맞추는 밤" } ]
     ]
   },
   {
-    "character": "매튜 전략가",
-    "place": "matthew-home-strategy",
+    "character": "세라",
+    "place": "신호 교차로",
     "sentences": [
       [
-        {
-          "message": "새벽 공기를 가르는 건 전면 보드에 그려 둔 하루의 전투 계획입니다."
-        },
-        {
-          "message": "고객 시나리오와 리스크, 집중할 시간을 한 줄씩 정리하며 호흡을 고릅니다.",
-          "asset": "emoji-focus"
-        }
+        { "message": "이 교차로, 패킷이 사방에서 몰려와. 어느 쪽부터 풀어야 하지?" }
       ],
       [
-        {
-          "message": "SP4 반도체 웹서비스에서 다져 둔 집요한 리듬이 손끝에서 다시 살아납니다."
-        },
-        {
-          "message": "전략과 실행의 간격을 줄이는 것이 오늘도 제 첫 번째 임무입니다."
-        }
+        { "message": "시간은 없고, 에러는 계속 올라오고 있어." }
       ]
     ]
   },
   {
-    "character": "매튜 탐험가",
-    "place": "matthew-home-lab",
+    "character": "루크",
+    "place": "신호 교차로",
     "sentences": [
       [
-        {
-          "message": "데스크 위 모니터에는 모노레포 구조도와 사용자 여정이 나란히 켜져 있습니다."
-        },
-        {
-          "message": "Nuxt와 SvelteKit 사이의 브릿지를 검토하며 최적의 실험 경로를 계산하죠.",
-          "asset": "emoji-focus"
-        }
+        { "message": "버퍼부터 정리해야지. 매튜, 너의 지도는 어디 있나?" }
       ],
       [
-        {
-          "message": "협업 채널에서 파트너들이 보낸 질문을 읽을 때면 미소가 번집니다."
-        },
-        {
-          "message": "제가 깔아 둔 가드레일 덕분에 모두가 안심하고 속도를 낼 수 있거든요.",
-          "asset": "emoji-joy"
-        }
+        { "message": "우린 선을 따라 움직일 준비가 되어 있어." }
       ]
     ]
   },
   {
-    "character": "매튜 멘토",
-    "place": "matthew-home-strategy",
+    "character": "매튜",
+    "place": "신호 교차로",
     "sentences": [
       [
-        {
-          "message": "영상 회의 속 동료들은 오늘도 제가 먼저 고객 관점을 짚어 주길 기대합니다."
-        },
-        {
-          "message": "요구사항이 바뀌면 새로운 경로를 바로 제시하며 팀의 체력을 지킵니다."
-        }
+        { "message": "두 사람 모두 고마워. 우선 포트 우선순위를 다시 맞추자." }
       ],
       [
-        {
-          "message": "집요한 추진력은 때로 과도한 에너지 소비를 불러오기도 합니다."
-        },
-        {
-          "message": "그래서 저는 일정마다 휴식 루틴을 적어 두고 스스로를 챙깁니다.",
-          "asset": "emoji-relief"
-        }
+        { "message": "세라, 서쪽 노드를 맡아. 루크는 로그를 추적해. 나는 중앙을 정렬할게.", "asset": "emotion-support" }
       ]
     ]
   },
   {
-    "character": "매튜 탐험가",
-    "place": "matthew-home-garden",
+    "character": "그리드",
+    "place": "신호 교차로",
     "sentences": [
       [
-        {
-          "message": "잠깐의 숨 고르기는 집 안뜰의 작은 정원에서 이어집니다."
-        },
-        {
-          "message": "자전거와 등산이 떠오르며 다음 모험을 위한 체력을 다시 채웁니다.",
-          "asset": "emoji-steady"
-        }
+        { "message": "또 팀워크라니. 혼자서 불태우던 너는 어디로 간 거지?" }
       ],
       [
-        {
-          "message": "기술은 결국 사람을 향한다는 다짐을 마음속에서 다시 한번 크게 외칩니다."
-        },
-        {
-          "message": "이 다짐이 저를 다시 작업실로 이끌고 새로운 도약을 준비하게 하죠.",
-          "asset": "emoji-joy"
-        }
+        { "message": "하지만 이런 리듬이라면, 나도 어쩌면 따라가 보고 싶군." }
       ]
     ]
   },
   {
+    "character": "엘리",
+    "place": "공명 실험실",
     "sentences": [
       [
-        {
-          "message": "다음 챕터에서는 매튜가 성장 환경을 어떻게 설계했는지 더 깊이 살펴보겠습니다."
-        },
-        {
-          "message": "준비되셨다면 함께 모험을 계속 이어가요!",
-          "asset": "emoji-joy"
-        }
+        { "message": "로그 정리 완료. 공명 실험실의 장비를 재설정했어." }
+      ],
+      [
+        { "message": "매튜, 이제 잔향을 분석하고 새 챕터의 뼈대를 짜 봐." }
+      ]
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "공명 실험실",
+    "sentences": [
+      [
+        { "message": "데이터 파형이 이렇게 깨끗하게 들리는 건 오랜만이야." }
+      ],
+      [
+        { "message": "다음 장면은 공중 정원에서 시작하자. 바람 소리가 힌트를 주고 있어.", "asset": "emotion-surprise" }
       ]
     ]
   }

--- a/public/chapter2.json
+++ b/public/chapter2.json
@@ -1,124 +1,78 @@
 [
   {
     "sentences": [
-      {
-        "message": "챕터 2 : 앞으로의 여정"
-      }
+      [ { "message": "CHAPTER 2 — 공중 정원의 결계" } ]
     ]
   },
   {
-    "character": "matthew",
-    "place": "developer",
+    "character": "해리",
+    "place": "공중 정원",
     "sentences": [
       [
-        {
-          "message": "지금 저는 더 나은 사용자 경험을 위한 설계를 계속 실험하고 있습니다.\n"
-        },
-        {
-          "message": "새로운 도구를 발견하면 작은 실험부터 시작합니다.",
-          "asset": "thumbs"
-        }
-      ],
-      {
-        "message": "실패한 실험도 기록으로 남겨 두고 다음 팀원이 다시 시도할 수 있게 합니다."
-      }
-    ]
-  },
-  {
-    "character": "matthew",
-    "place": "conversation",
-    "sentences": [
-      [
-        {
-          "message": "비즈니스 목표를 들으면 곧장 화면을 그리지 않습니다.\n"
-        },
-        {
-          "message": "데이터와 흐름을 먼저 질문하죠.",
-          "asset": "conversation"
-        }
+        { "message": "여긴 바람이 거꾸로 불어. 대사마다 이전 버전이 새어 나와." }
       ],
       [
-        {
-          "message": "그 다음에야 기획서와 디자인을 맞추고\n"
-        },
-        {
-          "message": "개발 일정과 리스크를 스스로 제안합니다."
-        }
-      ],
-      {
-        "message": "이렇게 만들어진 로드맵은 팀에게 신뢰를 줍니다."
-      }
-    ]
-  },
-  {
-    "character": "matthew",
-    "place": "now",
-    "sentences": [
-      [
-        {
-          "message": "요즘은 React와 Next로 구축한 디자인 시스템을 발전시키고 있습니다.\n"
-        },
-        {
-          "message": "필요하다면 Svelte나 Nuxt도 적극적으로 실험합니다.",
-          "asset": "react"
-        }
-      ],
-      [
-        {
-          "message": "상황에 맞는 도구를 고르는 능력 덕분에\n"
-        },
-        {
-          "message": "새로운 프로젝트에서도 빠르게 MVP를 완성할 수 있었습니다.",
-          "asset": "next"
-        }
-      ],
-      [
-        {
-          "message": "도구가 바뀌어도 사용자를 향한 마음은 같다는 것을\n"
-        },
-        {
-          "message": "늘 마음에 새기고 있습니다.",
-          "asset": "svelte"
-        }
-      ],
-      [
-        {
-          "message": "필요하다면 백엔드와 인프라까지 살펴보며\n"
-        },
-        {
-          "message": "전체 여정을 연결합니다.",
-          "asset": "nuxt"
-        }
+        { "message": "코드 가지치기를 어디서부터 해야 할까?" }
       ]
     ]
   },
   {
-    "character": "matthew",
-    "place": "street",
+    "character": "매튜",
+    "place": "공중 정원",
     "sentences": [
       [
-        {
-          "message": "제가 원하는 팀은 함께 배우고 성장하는 동료가 있는 곳입니다.\n"
-        },
-        {
-          "message": "그래서 저는 항상 지식을 공유하고, 기록하며, 다음 사람을 생각합니다."
-        }
+        { "message": "해리, 우리에겐 여섯 장의 배경만 있다." }
       ],
-      {
-        "message": "당신과 함께 다음 모험을 펼칠 날을 기대하고 있습니다."
-      }
+      [
+        { "message": "그래도 이야기를 다시 엮을 수 있다는 걸 보여 주자." }
+      ]
     ]
   },
   {
+    "character": "엘리",
+    "place": "공중 정원",
     "sentences": [
       [
-        {
-          "message": "매튜의 모험에 함께해 주셔서 감사합니다.\n"
-        },
-        {
-          "message": "이제 크레딧으로 이동해 더 많은 이야기를 나눠요!",
-          "asset": "noti"
-        }
+        { "message": "스크립트 역사 전체를 압축했어. 필요 없는 호출은 전부 삭제." }
+      ],
+      [
+        { "message": "남은 건 우리 감정뿐. 이모지 캔버스로 리듬을 그려 보자.", "asset": "emotion-relief" }
+      ]
+    ]
+  },
+  {
+    "character": "세라",
+    "place": "공중 정원",
+    "sentences": [
+      [
+        { "message": "그림자 캐릭터들도 다 정리했어. 이제 진짜 여섯 명만 무대에 설 거야." }
+      ],
+      [
+        { "message": "루크, 네 배포 순서 체크 끝났어?" }
+      ]
+    ]
+  },
+  {
+    "character": "루크",
+    "place": "공중 정원",
+    "sentences": [
+      [
+        { "message": "모든 경로 확인 완료. 매튜, 이제 결정을 내려." }
+      ],
+      [
+        { "message": "우리가 다시 쓰는 첫 장면은 어디로 향하지?", "asset": "emotion-determination" }
+      ]
+    ]
+  },
+  {
+    "character": "매튜",
+    "place": "공중 정원",
+    "sentences": [
+      [
+        { "message": "마지막 무대는 별빛 강당이야. 그곳에서 우리의 리부트를 선언하자." }
+      ],
+      [
+        { "message": "모두, 준비 완료 상태를 유지해." }
       ]
     ]
   }

--- a/public/chapter3.json
+++ b/public/chapter3.json
@@ -1,609 +1,91 @@
 [
   {
     "sentences": [
-      {
-        "message": "CHAPTER 1 — 잊혀진 코드의 나라"
-      }
+      [ { "message": "CHAPTER 3 — 별빛 강당의 리부트 선언" } ]
     ]
   },
   {
     "character": "매튜",
-    "place": "아메바 폐허",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "여긴… 어디지? 코드가… 살아 움직이고 있어?"
-      }
+      [
+        { "message": "자, 무대가 준비됐어. 이제 진짜로 시작하자." }
+      ],
+      [
+        { "message": "우리가 다시 쓴 서사는 오늘 여기서 공개된다." }
+      ]
     ]
   },
   {
     "character": "그리드",
-    "place": "아메바 폐허",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "깨어났구나, 매튜. 네가 남긴 코드가 괴물이 되었어."
-      }
+      [
+        { "message": "예전의 너라면 혼자 모든 걸 끌어안았겠지." }
+      ],
+      [
+        { "message": "지금의 넌 여섯 장의 공간과 여섯 명의 목소리를 조합했군." }
+      ]
     ]
   },
   {
-    "character": "매튜",
-    "place": "아메바 폐허",
+    "character": "엘리",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "내가 만든 코드가… 나를 공격하고 있다니."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "아메바 폐허",
-    "sentences": [
-      {
-        "message": "완벽함을 추구한 너의 집요함이 낳은 그림자야."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "아메바 폐허",
-    "sentences": [
-      {
-        "message": "그럼… 다시 정리해야지."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "아메바 폐허",
-    "sentences": [
-      {
-        "message": "시작하겠다는 건가?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "아메바 폐허",
-    "sentences": [
-      {
-        "message": "`Refactor Storm.` — 이제부터, 이 세상을 정리하겠어."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "아메바 폐허",
-    "sentences": [
-      {
-        "message": "네 손끝이 다시 불타는군. 하지만 잊지 마라, 불은 타오르면 사라진다."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "CHAPTER 2 — 세미티에스의 불꽃"
-      }
-    ]
-  },
-  {
-    "character": "루크",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "또 지각인가, 매튜? 팀이 너만 기다리고 있었어."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "죄송. 리빌드에 집중하느라 밤샜어."
-      }
+      [
+        { "message": "서버, 영상, 음향 모두 정상." }
+      ],
+      [
+        { "message": "이모지 감정 트랙도 잘 작동해. 준비 끝!", "asset": "emotion-surprise" }
+      ]
     ]
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "또 화장실도 안 갔지? 인간 맞아?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "이번만은 완벽하게 세팅하고 싶었어."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "완벽주의자끼리 모이면 불이 나지."
-      }
+      [
+        { "message": "관객 채널과 채팅을 연결했어. 피드백 루프를 놓치지 말자." }
+      ],
+      [
+        { "message": "첫 대사는 누가 가져갈래?" }
+      ]
     ]
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "불은 괜찮다. 문제는 협업이지."
-      }
+      [
+        { "message": "이미 대본은 돌고 있지. 매튜, 네가 첫 줄을 던져." }
+      ],
+      [
+        { "message": "우리가 지켜볼게.", "asset": "emotion-support" }
+      ]
+    ]
+  },
+  {
+    "character": "해리",
+    "place": "별빛 강당",
+    "sentences": [
+      [
+        { "message": "응답 속도 체크 완료. 관객의 심박도도 안정적이야." }
+      ],
+      [
+        { "message": "매튜, 마이크 켰다." }
+      ]
     ]
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "별빛 강당",
     "sentences": [
-      {
-        "message": "그럼 불을 하나로 묶자."
-      }
-    ]
-  },
-  {
-    "character": "세라",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "말은 멋지네. 방법은?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "`Monorepo Field.` — 모든 프로젝트를 하나의 불꽃으로."
-      }
-    ]
-  },
-  {
-    "character": "루크",
-    "place": "세미티에스 공업도시",
-    "sentences": [
-      {
-        "message": "좋아. 그 불로 우리 길을 밝히자."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "CHAPTER 3 — 업라이즈의 그림자"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "이곳이… 암호화폐의 요새, 업라이즈 시타델인가."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "조심해. 여기선 버그도 디지털로 암호화돼 있어."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "이 도시엔 네 과거의 그림자가 잠들어 있다."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "Nuxt의 유령들… 스벨트킷의 힘으로 해방시켜야겠어."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "또 한 번 리팩토링이군. 넌 그걸 즐기나 봐."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "즐긴다기보단… 집착하지."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "그 집착이 널 강하게도, 약하게도 만든다."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "괜찮아. 집중이 깨질 때까진 멈추지 않아."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "그 말, 위험하게 들린다."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "업라이즈 시타델",
-    "sentences": [
-      {
-        "message": "괜찮아. 난 Grit이니까."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "CHAPTER 4 — 한국일보 요새의 기사"
-      }
-    ]
-  },
-  {
-    "character": "세라",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "매튜! 기사 데이터가 폭주하고 있어!"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "시스템 로그 보여줘."
-      }
-    ]
-  },
-  {
-    "character": "루크",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "서버가 3초마다 죽고 있어."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "좋아, 패턴이 보여."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "지금 그럴 여유 없어!"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "(눈 감으며) 집중모드로 들어간다. 누구도 건드리지 마."
-      }
-    ]
-  },
-  {
-    "character": "세라",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "또 화장실도 안 갈 거야?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "끝내고 간다."
-      }
-    ]
-  },
-  {
-    "character": "루크",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "이런 미친 집중력…"
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "네 불이 너무 밝다, 매튜. 타버릴 거야."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "괜찮아. 이 불로 요새를 구할 수 있다면."
-      }
-    ]
-  },
-  {
-    "character": "세라",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "기사 관리 시스템, 복구 완료!"
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "매튜, 넌 또 해냈군."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "한국일보 요새",
-    "sentences": [
-      {
-        "message": "(미소짓고) 아직은… 살아있네."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "CHAPTER 5 — 낭비 없는 왕국"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "이젠 알겠어. 완벽이 아니라 효율이야."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "네가 그 말을 하다니. 믿을 수가 없군."
-      }
-    ]
-  },
-  {
-    "character": "세라",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "‘짠돌이 왕국’이라더니 진짜 절약 모드야?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "낭비는 죄야. 시간도, 코드도, 체력도."
-      }
-    ]
-  },
-  {
-    "character": "루크",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "하지만 인간은 기계가 아니잖아."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "그래서 지금은… 분배를 배워야 해."
-      }
-    ]
-  },
-  {
-    "character": "엘리",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "드디어 네 안의 Grit이 균형을 찾는군."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "`Grit Engine.` — 불필요한 모든 걸 제거하고 본질만 남긴다."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "낭비 없는 왕국",
-    "sentences": [
-      {
-        "message": "잘했다, 매튜. 이제 진짜 완성형이 되었구나."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "FINAL CHAPTER — 그리드와의 대면"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "이제 마지막이군…"
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "그래. 이젠 나와 싸워야 한다."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "넌 내 일부야. 없애지 않아도 돼."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "그럼 왜 칼을 들었지?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "두려워서가 아니야. 확인하려고."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "네 불은 더 이상 타오르지 않는데?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "아니, 이젠 따뜻하게 빛나고 있어."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "…이게 균형이구나."
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "그래. 난 더 이상 나를 태우지 않아도 돼."
-      }
-    ]
-  },
-  {
-    "character": "그리드",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "그럼 네 모험은 끝난 건가?"
-      }
-    ]
-  },
-  {
-    "character": "매튜",
-    "place": "내면의 제단",
-    "sentences": [
-      {
-        "message": "아니, 이제 시작이야. 세상을 리팩토링할 차례지."
-      }
-    ]
-  },
-  {
-    "sentences": [
-      {
-        "message": "(조용히 화면이 어두워지며, 매튜의 엔진 소리만 들린다.)"
-      }
+      [
+        { "message": "모두 고마워. 이제 우리의 목소리로 세상을 리팩토링하자." }
+      ],
+      [
+        { "message": "여섯 장의 무대는 다시 확장될 거야. 하지만 우리는 이 시작을 잊지 않겠지.", "asset": "emotion-hope" }
+      ]
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- rebuild all chapter scripts from scratch so each scene uses only the six approved backgrounds and six characters
- synchronize every assets file with the reduced art set and reference new composite emoji emotion markers
- add SVG emoji combinations to visualize emotional cues for the refreshed dialogue

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68fccf660adc8331b29998f720b7bbc5