### PR TITLE
Make emotion emoji backgrounds transparent

### DIFF
--- a/public/assets/emotion-determination.svg
+++ b/public/assets/emotion-determination.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="#101321"/>
+  <rect width="200" height="200" rx="24" fill="none"/>
   <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle" font-size="64">🔥⚙️</text>
   <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="56">💪</text>
 </svg>

--- a/public/assets/emotion-hope.svg
+++ b/public/assets/emotion-hope.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="#131c2a"/>
+  <rect width="200" height="200" rx="24" fill="none"/>
   <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="60">🌅🚀</text>
   <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-size="52">🙂</text>
 </svg>

--- a/public/assets/emotion-relief.svg
+++ b/public/assets/emotion-relief.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="#0f1d1a"/>
+  <rect width="200" height="200" rx="24" fill="none"/>
   <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="60">🌿😌</text>
   <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="54">✨</text>
 </svg>

--- a/public/assets/emotion-support.svg
+++ b/public/assets/emotion-support.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="#111a2b"/>
+  <rect width="200" height="200" rx="24" fill="none"/>
   <text x="50%" y="42%" dominant-baseline="middle" text-anchor="middle" font-size="58">🤝😊</text>
   <text x="50%" y="78%" dominant-baseline="middle" text-anchor="middle" font-size="54">🌟</text>
 </svg>

--- a/public/assets/emotion-surprise.svg
+++ b/public/assets/emotion-surprise.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="#1a1326"/>
+  <rect width="200" height="200" rx="24" fill="none"/>
   <text x="50%" y="44%" dominant-baseline="middle" text-anchor="middle" font-size="60">⚡😲</text>
   <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-size="50">💬</text>
 </svg>


### PR DESCRIPTION
## Summary
- make the background rectangles in emotion emoji SVG assets transparent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fce22d01548331bafdaedb2fad8cf2