### PR TITLE
Improve emoji staging and expand chapter dialogue

### DIFF
--- a/public/chapter1.json
+++ b/public/chapter1.json
@@ -2,16 +2,24 @@
   {
     "sentences": [
       [
-        { "message": "CHAPTER 2 — 데이터의 불꽃 (인터파크 & 와이즈버즈 시절)" }
+        {
+          "message": "CHAPTER 2 — 데이터의 불꽃 (인터파크 & 와이즈버즈 시절)"
+        }
       ],
       [
-        { "message": "배경: 거대한 코드 시장 ‘인터파크 성채’와 ‘와이즈버즈 연구소’." }
+        {
+          "message": "배경: 거대한 코드 시장 ‘인터파크 성채’와 ‘와이즈버즈 연구소’."
+        }
       ],
       [
-        { "message": "상징: 도전과 도입, 팀 리빌드의 시작." }
+        {
+          "message": "상징: 도전과 도입, 팀 리빌드의 시작."
+        }
       ],
       [
-        { "message": "키워드: 데이터 이입, 조직 재편, 실험 정신." }
+        {
+          "message": "키워드: 데이터 이입, 조직 재편, 실험 정신."
+        }
       ]
     ]
   },
@@ -20,10 +28,27 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "새로운 언어가 등장했어. 타입스크립트, Vue, 그리고 끝없는 데이터 스트림.", "asset": ["emoji-rocket", "emoji-gear"] }
+        {
+          "message": "새로운 언어가 등장했어. 타입스크립트, Vue, 그리고 끝없는 데이터 스트림.",
+          "asset": [
+            "emoji-rocket",
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "규칙을 익히는 건 빠를수록 좋아. 그래야 시장이 뒤집혀도 손이 먼저 움직이지." }
+        {
+          "message": "규칙을 익히는 건 빠를수록 좋아. 그래야 시장이 뒤집혀도 손이 먼저 움직이지."
+        }
+      ],
+      [
+        {
+          "message": "신입들이 헤매면 야근 전에 라면 끓여줄까? 농담이야, 대신 온보딩 가이드를 오늘 밤에라도 고쳐둘게.",
+          "asset": [
+            "emoji-speech",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -32,10 +57,27 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "문법은 다르지만 해결해야 할 문제는 같아. 의미를 잃지 않는 UI를 만드는 것.", "asset": ["emoji-fire", "emoji-speech"] }
+        {
+          "message": "문법은 다르지만 해결해야 할 문제는 같아. 의미를 잃지 않는 UI를 만드는 것.",
+          "asset": [
+            "emoji-fire",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "이번엔 데이터 흐름까지 내 통제 안에 두겠어." }
+        {
+          "message": "이번엔 데이터 흐름까지 내 통제 안에 두겠어."
+        }
+      ],
+      [
+        {
+          "message": "루크, 네 농담 덕분에 긴장이 풀려. 대신 우리는 체크리스트와 자동화로 새벽을 버틸 거야.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-gear"
+          ]
+        }
       ]
     ]
   },
@@ -44,10 +86,27 @@
     "place": "와이즈버즈 연구소",
     "sentences": [
       [
-        { "message": "사용자 리서치 결과 공유해요. 검색 레이어에서 대부분 이탈하더라고요.", "asset": ["emoji-speech", "emoji-leaf"] }
+        {
+          "message": "사용자 리서치 결과 공유해요. 검색 레이어에서 대부분 이탈하더라고요.",
+          "asset": [
+            "emoji-speech",
+            "emoji-leaf"
+          ]
+        }
       ],
       [
-        { "message": "UI는 설명이 아니라 경험이니까, 당신 말투 대신 유저의 손을 빌릴게요." }
+        {
+          "message": "UI는 설명이 아니라 경험이니까, 당신 말투 대신 유저의 손을 빌릴게요."
+        }
+      ],
+      [
+        {
+          "message": "내가 밤새 필드 노트를 정리한 김에, 인터뷰 비하인드도 슬랙에 풀어둘게요.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -56,10 +115,27 @@
     "place": "와이즈버즈 연구소",
     "sentences": [
       [
-        { "message": "속도 지표 업데이트! 전환율이 2%만 떨어져도 광고 수익이 갈려.", "asset": ["emoji-bolt", "emoji-surprised"] }
+        {
+          "message": "속도 지표 업데이트! 전환율이 2%만 떨어져도 광고 수익이 갈려.",
+          "asset": [
+            "emoji-bolt",
+            "emoji-surprised"
+          ]
+        }
       ],
       [
-        { "message": "실험은 좋지만, 실패 로그도 바로 복구할 프로토콜 세팅해줘." }
+        {
+          "message": "실험은 좋지만, 실패 로그도 바로 복구할 프로토콜 세팅해줘."
+        }
+      ],
+      [
+        {
+          "message": "나는 커피 줄일 테니까 넌 경보음 볼륨만 살살 다뤄줘. 모두가 잠깐은 숨을 쉬어야 하니까.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-sunrise"
+          ]
+        }
       ]
     ]
   },
@@ -68,10 +144,27 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "팀을 다시 짜보자. 네가 직접 설계한 워크플로가 필요해.", "asset": ["emoji-handshake", "emoji-sparkle"] }
+        {
+          "message": "팀을 다시 짜보자. 네가 직접 설계한 워크플로가 필요해.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-sparkle"
+          ]
+        }
       ],
       [
-        { "message": "도입은 혼자 하는 게 아니야. 사람을 움직일 언어와 리듬을 정해야지." }
+        {
+          "message": "도입은 혼자 하는 게 아니야. 사람을 움직일 언어와 리듬을 정해야지."
+        }
+      ],
+      [
+        {
+          "message": "회의 끝나면 맥주 한 캔은 괜찮지? 성공이든 실패든 우리끼리 웃을 언어가 필요해.",
+          "asset": [
+            "emoji-smile",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -80,10 +173,27 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "그래서 회고를 매일로 바꾸고, 리뷰 룰을 전부 모듈화했어.", "asset": ["emoji-gear", "emoji-speech"] }
+        {
+          "message": "그래서 회고를 매일로 바꾸고, 리뷰 룰을 전부 모듈화했어.",
+          "asset": [
+            "emoji-gear",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "나는 이제 손이 아니라 흐름을 조율하는 사람이다." }
+        {
+          "message": "나는 이제 손이 아니라 흐름을 조율하는 사람이다."
+        }
+      ],
+      [
+        {
+          "message": "밤샘 대신 산책 미팅을 도입하면 어때? 코드 얘기하다가도 도시의 소리가 우리 편이 되게.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-relaxed"
+          ]
+        }
       ]
     ]
   },
@@ -92,10 +202,27 @@
     "place": "와이즈버즈 연구소",
     "sentences": [
       [
-        { "message": "덕분에 접근성 체크리스트가 언어처럼 굴러가기 시작했어요.", "asset": ["emoji-smile", "emoji-star"] }
+        {
+          "message": "덕분에 접근성 체크리스트가 언어처럼 굴러가기 시작했어요.",
+          "asset": [
+            "emoji-smile",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "팀이 왜 움직이는지 각자 말할 수 있게 문서를 짜둘게요." }
+        {
+          "message": "팀이 왜 움직이는지 각자 말할 수 있게 문서를 짜둘게요."
+        }
+      ],
+      [
+        {
+          "message": "그리고 주말엔 독서 모임 어때요? 창의성은 결국 다른 이야기에서 오잖아요.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -104,10 +231,26 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "하지만 넌 여전히 완벽한 답을 찾을 때까지 잠들지 못하잖아.", "asset": ["emoji-bolt"] }
+        {
+          "message": "하지만 넌 여전히 완벽한 답을 찾을 때까지 잠들지 못하잖아.",
+          "asset": [
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "이번엔 누구에게 기대려 하지도 않지?" }
+        {
+          "message": "이번엔 누구에게 기대려 하지도 않지?"
+        }
+      ],
+      [
+        {
+          "message": "가끔은 나도 네 걱정이야. 커피 머신 앞에서 멍 때리는 네 뒷모습이 익숙해졌거든.",
+          "asset": [
+            "emoji-surprised",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -116,10 +259,27 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "기대는 해. 책임을 나누기 위해 시스템을 만들고 있으니까.", "asset": ["emoji-handshake", "emoji-muscle"] }
+        {
+          "message": "기대는 해. 책임을 나누기 위해 시스템을 만들고 있으니까.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-muscle"
+          ]
+        }
       ],
       [
-        { "message": "새벽을 버티는 불씨는 혼자지만, 새벽을 여는 태양은 모두에게 나눌 거야." }
+        {
+          "message": "새벽을 버티는 불씨는 혼자지만, 새벽을 여는 태양은 모두에게 나눌 거야."
+        }
+      ],
+      [
+        {
+          "message": "다음 주엔 팀 캠핑 가자. 불꽃 앞에서 얘기하면 복잡한 데이터도 결국 사람 얘기로 들리거든.",
+          "asset": [
+            "emoji-fire",
+            "emoji-sunrise"
+          ]
+        }
       ]
     ]
   },
@@ -128,10 +288,26 @@
     "place": "인터파크 성채",
     "sentences": [
       [
-        { "message": "흐음, 네 목소리에 리더 톤이 묻어난다.", "asset": ["emoji-star"] }
+        {
+          "message": "흐음, 네 목소리에 리더 톤이 묻어난다.",
+          "asset": [
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "그 불꽃이 팀을 델타로 만들 수 있을지 지켜보지." }
+        {
+          "message": "그 불꽃이 팀을 델타로 만들 수 있을지 지켜보지."
+        }
+      ],
+      [
+        {
+          "message": "나도 일지에 적어둘게. 오늘은 매튜가 웃었다고. 그게 우리 프로젝트의 좋은 지표니까.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   }

--- a/public/chapter2.json
+++ b/public/chapter2.json
@@ -2,16 +2,24 @@
   {
     "sentences": [
       [
-        { "message": "CHAPTER 3 — 업라이즈의 그림자 (Uprise & Heybit 시절)" }
+        {
+          "message": "CHAPTER 3 — 업라이즈의 그림자 (Uprise & Heybit 시절)"
+        }
       ],
       [
-        { "message": "배경: 암호화된 데이터 왕국 ‘업라이즈 시타델’." }
+        {
+          "message": "배경: 암호화된 데이터 왕국 ‘업라이즈 시타델’."
+        }
       ],
       [
-        { "message": "상징: 집중력, 몰입, 그리고 건강의 경계." }
+        {
+          "message": "상징: 집중력, 몰입, 그리고 건강의 경계."
+        }
       ],
       [
-        { "message": "키워드: 암호화, 재사용 컴포넌트, 회복 루틴." }
+        {
+          "message": "키워드: 암호화, 재사용 컴포넌트, 회복 루틴."
+        }
       ]
     ]
   },
@@ -20,10 +28,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "터미널이 숨을 쉬는 소리가 들려. 암호화 키가 심장박동 같아.", "asset": ["emoji-bolt", "emoji-rocket"] }
+        {
+          "message": "터미널이 숨을 쉬는 소리가 들려. 암호화 키가 심장박동 같아.",
+          "asset": [
+            "emoji-bolt",
+            "emoji-rocket"
+          ]
+        }
       ],
       [
-        { "message": "여기서는 한 줄이 천만 원을 움직이겠지." }
+        {
+          "message": "여기서는 한 줄이 천만 원을 움직이겠지."
+        }
+      ],
+      [
+        {
+          "message": "오늘 야근은 없길 바라지만, 그래도 야식 대신 전해질 음료 챙겼어.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-sunrise"
+          ]
+        }
       ]
     ]
   },
@@ -32,10 +57,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "그래서 네 눈빛이 달라졌구나. 금융은 속도와 신뢰의 동시 통역을 요구해.", "asset": ["emoji-handshake", "emoji-star"] }
+        {
+          "message": "그래서 네 눈빛이 달라졌구나. 금융은 속도와 신뢰의 동시 통역을 요구해.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "문서화부터 암호화 플로우까지, 모두가 읽을 언어로 남겨." }
+        {
+          "message": "문서화부터 암호화 플로우까지, 모두가 읽을 언어로 남겨."
+        }
+      ],
+      [
+        {
+          "message": "비상회의 끝나면 체스 한 판 어때? 머리 식히는 데엔 전략 게임이 최고야.",
+          "asset": [
+            "emoji-gear",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -44,10 +86,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "Shadow DOM 라이브러리 초안 가져왔어요!", "asset": ["emoji-sparkle", "emoji-gear"] }
+        {
+          "message": "Shadow DOM 라이브러리 초안 가져왔어요!",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "디자이너랑 직접 대화할 수 있도록, 토큰 시스템도 열어둘게요." }
+        {
+          "message": "디자이너랑 직접 대화할 수 있도록, 토큰 시스템도 열어둘게요."
+        }
+      ],
+      [
+        {
+          "message": "라이브러리 데모 끝나고 파이 먹으러 가요? 오늘은 코드보다 당충전이 급해요.",
+          "asset": [
+            "emoji-speech",
+            "emoji-star"
+          ]
+        }
       ]
     ]
   },
@@ -56,10 +115,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "좋아, 재사용성과 커스터마이징을 동시에 잡자.", "asset": ["emoji-gear", "emoji-rocket"] }
+        {
+          "message": "좋아, 재사용성과 커스터마이징을 동시에 잡자.",
+          "asset": [
+            "emoji-gear",
+            "emoji-rocket"
+          ]
+        }
       ],
       [
-        { "message": "우리가 만든 컴포넌트가 파생 서비스를 품을 수 있게 구조를 개방해야 해." }
+        {
+          "message": "우리가 만든 컴포넌트가 파생 서비스를 품을 수 있게 구조를 개방해야 해."
+        }
+      ],
+      [
+        {
+          "message": "재사용 가이드엔 농담도 넣어둘게. 다들 웃어야 유지보수도 덜 아프거든.",
+          "asset": [
+            "emoji-smile",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -68,10 +144,26 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "그 대신 네 잠은 닫히겠지.", "asset": ["emoji-bolt"] }
+        {
+          "message": "그 대신 네 잠은 닫히겠지.",
+          "asset": [
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "몰입은 칼날이야. 스스로를 벨 각오가 되어 있나?" }
+        {
+          "message": "몰입은 칼날이야. 스스로를 벨 각오가 되어 있나?"
+        }
+      ],
+      [
+        {
+          "message": "네가 졸면 내가 먼저 알아차릴 거야. 눈 밑 그림자는 내 전문 분야니까.",
+          "asset": [
+            "emoji-bolt",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -80,10 +172,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "칼날을 칼집에 넣는 법부터 배운다.", "asset": ["emoji-leaf", "emoji-relaxed"] }
+        {
+          "message": "칼날을 칼집에 넣는 법부터 배운다.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-relaxed"
+          ]
+        }
       ],
       [
-        { "message": "집중 시간을 측정해서 한계를 넘지 않게 스스로를 끊어내겠어." }
+        {
+          "message": "집중 시간을 측정해서 한계를 넘지 않게 스스로를 끊어내겠어."
+        }
+      ],
+      [
+        {
+          "message": "집중 타이머 끝나면 모두 스트레칭 체크하고 인증샷 올리기다.",
+          "asset": [
+            "emoji-muscle",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   },
@@ -92,10 +201,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "좋았어! 모니터링 봇이 새벽마다 울부짖는 걸 내가 막아줄게.", "asset": ["emoji-surprised", "emoji-speech"] }
+        {
+          "message": "좋았어! 모니터링 봇이 새벽마다 울부짖는 걸 내가 막아줄게.",
+          "asset": [
+            "emoji-surprised",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "대신 장애 보고는 30분 이내에 다큐먼트로 남겨. 투자자도 읽게 될 테니까." }
+        {
+          "message": "대신 장애 보고는 30분 이내에 다큐먼트로 남겨. 투자자도 읽게 될 테니까."
+        }
+      ],
+      [
+        {
+          "message": "모니터링 봇 이름을 '꼬꼬닭'으로 바꿀까? 새벽마다 우리 대신 울어줄 테니까.",
+          "asset": [
+            "emoji-speech",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -104,10 +230,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "그리고 팀에 '집중 스프린트' 룰을 도입하자.", "asset": ["emoji-handshake", "emoji-sunrise"] }
+        {
+          "message": "그리고 팀에 '집중 스프린트' 룰을 도입하자.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-sunrise"
+          ]
+        }
       ],
       [
-        { "message": "시간을 태우는 대신 에너지를 순환시켜. 그래야 다음 전투를 준비하지." }
+        {
+          "message": "시간을 태우는 대신 에너지를 순환시켜. 그래야 다음 전투를 준비하지."
+        }
+      ],
+      [
+        {
+          "message": "집중 스프린트 끝나면 스튜디오 불 꺼. 야근 조명은 이젠 추억으로만 남겨.",
+          "asset": [
+            "emoji-sunrise",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -116,10 +259,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "그래, 몰입과 회복을 쌍으로 묶을게.", "asset": ["emoji-leaf", "emoji-muscle"] }
+        {
+          "message": "그래, 몰입과 회복을 쌍으로 묶을게.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-muscle"
+          ]
+        }
       ],
       [
-        { "message": "내 코드는 자산을 지키는 방패고, 나는 방패를 관리하는 사람이다." }
+        {
+          "message": "내 코드는 자산을 지키는 방패고, 나는 방패를 관리하는 사람이다."
+        }
+      ],
+      [
+        {
+          "message": "다음 주엔 휴식 로그도 공유하자. 쉬는 법을 배우는 것도 우리의 실력이지.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -128,10 +288,27 @@
     "place": "업라이즈 시타델",
     "sentences": [
       [
-        { "message": "그러면 우린 더 이상 번아웃을 무용담으로 소비하지 않아도 되겠네요.", "asset": ["emoji-smile", "emoji-speech"] }
+        {
+          "message": "그러면 우린 더 이상 번아웃을 무용담으로 소비하지 않아도 되겠네요.",
+          "asset": [
+            "emoji-smile",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "다음 회의엔 건강 지표도 대시보드에 넣어둘게요." }
+        {
+          "message": "다음 회의엔 건강 지표도 대시보드에 넣어둘게요."
+        }
+      ],
+      [
+        {
+          "message": "건강 대시보드엔 반려식물 성장 그래프도 추가해볼래요? 사무실 공기도 중요하죠.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   }

--- a/public/chapter3.json
+++ b/public/chapter3.json
@@ -2,16 +2,24 @@
   {
     "sentences": [
       [
-        { "message": "CHAPTER 4 — 세미티에스의 요새 (Semites 시절)" }
+        {
+          "message": "CHAPTER 4 — 세미티에스의 요새 (Semites 시절)"
+        }
       ],
       [
-        { "message": "배경: 반도체 제국의 거대한 공장." }
+        {
+          "message": "배경: 반도체 제국의 거대한 공장."
+        }
       ],
       [
-        { "message": "상징: 구조 설계, 리더십, 그리고 협업의 본질." }
+        {
+          "message": "상징: 구조 설계, 리더십, 그리고 협업의 본질."
+        }
       ],
       [
-        { "message": "키워드: 모노레포, 도메인 설계, 판단 로그." }
+        {
+          "message": "키워드: 모노레포, 도메인 설계, 판단 로그."
+        }
       ]
     ]
   },
@@ -20,10 +28,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "모노레포 지도 펼쳐봐. 모듈 경계부터 다시 긋자.", "asset": ["emoji-gear", "emoji-bolt"] }
+        {
+          "message": "모노레포 지도 펼쳐봐. 모듈 경계부터 다시 긋자.",
+          "asset": [
+            "emoji-gear",
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "한 번 잘못 그으면 전선 전체가 꼬여." }
+        {
+          "message": "한 번 잘못 그으면 전선 전체가 꼬여."
+        }
+      ],
+      [
+        {
+          "message": "도면 옆에 커피 얼룩이 번지면 안 돼. 다들 전용 컵받침 챙겨.",
+          "asset": [
+            "emoji-gear",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -32,10 +57,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "그러니까 도메인 별로 전선을 끊어 배치하려 해.", "asset": ["emoji-fire", "emoji-gear"] }
+        {
+          "message": "그러니까 도메인 별로 전선을 끊어 배치하려 해.",
+          "asset": [
+            "emoji-fire",
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "각 서비스가 독립적으로 배포되면서도, 공통 라이브러리는 진화하도록." }
+        {
+          "message": "각 서비스가 독립적으로 배포되면서도, 공통 라이브러리는 진화하도록."
+        }
+      ],
+      [
+        {
+          "message": "오늘 밤엔 회로 대신 별 좀 보자. 천장 개방해둔 거 기억하지?",
+          "asset": [
+            "emoji-sunrise",
+            "emoji-relaxed"
+          ]
+        }
       ]
     ]
   },
@@ -44,10 +86,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "디자인 시스템도 그 구조에 맞춰 리팩토링할게요.", "asset": ["emoji-sparkle", "emoji-star"] }
+        {
+          "message": "디자인 시스템도 그 구조에 맞춰 리팩토링할게요.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "공장 인력이 바뀌어도 인터페이스는 같은 언어를 말하게 해야죠." }
+        {
+          "message": "공장 인력이 바뀌어도 인터페이스는 같은 언어를 말하게 해야죠."
+        }
+      ],
+      [
+        {
+          "message": "디자인 QA 중간에 군고구마라도 구워 먹을까요? 공장 열기가 아깝네요.",
+          "asset": [
+            "emoji-fire",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -56,10 +115,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "퍼포먼스 로거를 붙였어. 공정 한 번 멈추면 손해가 산처럼 쌓여.", "asset": ["emoji-bolt", "emoji-surprised"] }
+        {
+          "message": "퍼포먼스 로거를 붙였어. 공정 한 번 멈추면 손해가 산처럼 쌓여.",
+          "asset": [
+            "emoji-bolt",
+            "emoji-surprised"
+          ]
+        }
       ],
       [
-        { "message": "캐시 정책까지 명세로 박아둬." }
+        {
+          "message": "캐시 정책까지 명세로 박아둬."
+        }
+      ],
+      [
+        {
+          "message": "로그 이름에 농담 붙이면 안 돼? 밤새 보다 보면 웃음이라도 필요하거든.",
+          "asset": [
+            "emoji-speech",
+            "emoji-surprised"
+          ]
+        }
       ]
     ]
   },
@@ -68,10 +144,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "이제 네 역할은 조립이 아니라 지휘야.", "asset": ["emoji-handshake", "emoji-sunrise"] }
+        {
+          "message": "이제 네 역할은 조립이 아니라 지휘야.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-sunrise"
+          ]
+        }
       ],
       [
-        { "message": "회의를 줄이는 대신 결정 로그를 남겨. 사람들은 리더의 판단 근거를 믿으니까." }
+        {
+          "message": "회의를 줄이는 대신 결정 로그를 남겨. 사람들은 리더의 판단 근거를 믿으니까."
+        }
+      ],
+      [
+        {
+          "message": "지휘관도 점심은 챙겨. 내가 김밥 말아왔으니까 회의실에서 나눠 먹자.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -80,10 +173,26 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "결정이 쌓일수록 부담도 더해진다.", "asset": ["emoji-bolt"] }
+        {
+          "message": "결정이 쌓일수록 부담도 더해진다.",
+          "asset": [
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "모든 결과에 서명할 생각이야?" }
+        {
+          "message": "모든 결과에 서명할 생각이야?"
+        }
+      ],
+      [
+        {
+          "message": "너 덕분에 내 수첩엔 경고 대신 기대가 늘었어. 기분이 묘하군.",
+          "asset": [
+            "emoji-star",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -92,10 +201,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "그래. 대신 서명을 분산할 팀을 만들 거야.", "asset": ["emoji-handshake", "emoji-muscle"] }
+        {
+          "message": "그래. 대신 서명을 분산할 팀을 만들 거야.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-muscle"
+          ]
+        }
       ],
       [
-        { "message": "리뷰어와 오너를 명확히 나누고, 실패를 기록하는 문화를 박제하자." }
+        {
+          "message": "리뷰어와 오너를 명확히 나누고, 실패를 기록하는 문화를 박제하자."
+        }
+      ],
+      [
+        {
+          "message": "분산된 서명 리스트에 농담 섹션도 넣자. 웃음이 있어야 책임도 버틸 수 있어.",
+          "asset": [
+            "emoji-smile",
+            "emoji-handshake"
+          ]
+        }
       ]
     ]
   },
@@ -104,10 +230,27 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "이미 문서 도구에 섹션 만들어뒀어요.", "asset": ["emoji-speech", "emoji-smile"] }
+        {
+          "message": "이미 문서 도구에 섹션 만들어뒀어요.",
+          "asset": [
+            "emoji-speech",
+            "emoji-smile"
+          ]
+        }
       ],
       [
-        { "message": "각 파트 리드가 한 주의 결정을 스스로 적게 하면, 당신 어깨도 가벼워질 거예요." }
+        {
+          "message": "각 파트 리드가 한 주의 결정을 스스로 적게 하면, 당신 어깨도 가벼워질 거예요."
+        }
+      ],
+      [
+        {
+          "message": "회고 문서에 낙서 칸 하나 만들었어요. 다들 그림 실력도 공유해요.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -116,10 +259,26 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "좋아, 이제야 군단이 보이네.", "asset": ["emoji-star"] }
+        {
+          "message": "좋아, 이제야 군단이 보이네.",
+          "asset": [
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "그리드, 네 주인이 드디어 허리를 폈다." }
+        {
+          "message": "그리드, 네 주인이 드디어 허리를 폈다."
+        }
+      ],
+      [
+        {
+          "message": "군단이라면 군가도 있어야지. 회의 전에 우리가 만든 비트 한번 틀어볼까?",
+          "asset": [
+            "emoji-rocket",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   },
@@ -128,10 +287,26 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "허리를 펴면 넘어지기도 쉬운 법.", "asset": ["emoji-gear"] }
+        {
+          "message": "허리를 펴면 넘어지기도 쉬운 법.",
+          "asset": [
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "하지만... 나도 슬슬 기대가 되는데." }
+        {
+          "message": "하지만... 나도 슬슬 기대가 되는데."
+        }
+      ],
+      [
+        {
+          "message": "기대는 무섭지만 달콤해. 그래서 더 조심히 걸을게.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-star"
+          ]
+        }
       ]
     ]
   },
@@ -140,7 +315,22 @@
     "place": "세미티에스 요새",
     "sentences": [
       [
-        { "message": "우린 함께 지탱할 거야. 이 공장의 리듬은 이제 우리의 언어니까.", "asset": ["emoji-sparkle", "emoji-handshake"] }
+        {
+          "message": "우린 함께 지탱할 거야. 이 공장의 리듬은 이제 우리의 언어니까.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-handshake"
+          ]
+        }
+      ],
+      [
+        {
+          "message": "오늘 퇴근길엔 공장 뒤 언덕에서 바람 좀 쐬고 가자. 이 리듬을 밖에서도 느껴보고 싶어.",
+          "asset": [
+            "emoji-leaf",
+            "emoji-sunrise"
+          ]
+        }
       ]
     ]
   }

--- a/public/chapter4.json
+++ b/public/chapter4.json
@@ -2,16 +2,24 @@
   {
     "sentences": [
       [
-        { "message": "CHAPTER 5 — 한국일보의 빛 (Korea Times 프로젝트)" }
+        {
+          "message": "CHAPTER 5 — 한국일보의 빛 (Korea Times 프로젝트)"
+        }
       ],
       [
-        { "message": "배경: 디지털 기사 관리 시스템 ‘햄스 요새’." }
+        {
+          "message": "배경: 디지털 기사 관리 시스템 ‘햄스 요새’."
+        }
       ],
       [
-        { "message": "상징: 집요함과 혁신의 융합." }
+        {
+          "message": "상징: 집요함과 혁신의 융합."
+        }
       ],
       [
-        { "message": "키워드: 뉴스 워크플로, 자동화, 현장 공감." }
+        {
+          "message": "키워드: 뉴스 워크플로, 자동화, 현장 공감."
+        }
       ]
     ]
   },
@@ -20,10 +28,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "에디터가 멈추면 기자들이 전부 슬랙에 난리쳐요!", "asset": ["emoji-surprised", "emoji-speech"] }
+        {
+          "message": "에디터가 멈추면 기자들이 전부 슬랙에 난리쳐요!",
+          "asset": [
+            "emoji-surprised",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "리치텍스트 모듈부터 안정화해야 해요." }
+        {
+          "message": "리치텍스트 모듈부터 안정화해야 해요."
+        }
+      ],
+      [
+        {
+          "message": "기자 분들이 야식 보내준대요. 밤에 김치전 냄새 나면 제 탓이에요.",
+          "asset": [
+            "emoji-speech",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -32,10 +57,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "로그를 파봤는데, 번들 캐시가 꼬였더라.", "asset": ["emoji-gear", "emoji-bolt"] }
+        {
+          "message": "로그를 파봤는데, 번들 캐시가 꼬였더라.",
+          "asset": [
+            "emoji-gear",
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "즉시 롤백 포인트를 만들어둬." }
+        {
+          "message": "즉시 롤백 포인트를 만들어둬."
+        }
+      ],
+      [
+        {
+          "message": "롤백 포인트엔 코드네임 붙여둬. '호랑이', '고양이'처럼 기억나게.",
+          "asset": [
+            "emoji-gear",
+            "emoji-star"
+          ]
+        }
       ]
     ]
   },
@@ -44,10 +86,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "비동기 호출을 조립하는 대신, 파이프라인을 재정의하자.", "asset": ["emoji-fire", "emoji-gear"] }
+        {
+          "message": "비동기 호출을 조립하는 대신, 파이프라인을 재정의하자.",
+          "asset": [
+            "emoji-fire",
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "문서 작성-검수-발행을 하나의 상태 머신으로 묶어서 오류를 줄일 수 있어." }
+        {
+          "message": "문서 작성-검수-발행을 하나의 상태 머신으로 묶어서 오류를 줄일 수 있어."
+        }
+      ],
+      [
+        {
+          "message": "상태 머신 다이어그램 옆에 기자 사진 붙여둘래. 우리가 위해 달리는 사람들이니까.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   },
@@ -56,10 +115,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "그리고 기자들의 목소리부터 들어.", "asset": ["emoji-speech", "emoji-handshake"] }
+        {
+          "message": "그리고 기자들의 목소리부터 들어.",
+          "asset": [
+            "emoji-speech",
+            "emoji-handshake"
+          ]
+        }
       ],
       [
-        { "message": "현장과 개발이 같은 페이지를 읽어야 진짜 혁신이 완성돼." }
+        {
+          "message": "현장과 개발이 같은 페이지를 읽어야 진짜 혁신이 완성돼."
+        }
+      ],
+      [
+        {
+          "message": "현장 인터뷰 갈 때 나도 따라가도 돼? 새벽 공기 맡으면 각성되더라.",
+          "asset": [
+            "emoji-sunrise",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -68,10 +144,26 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "또다시 네 불꽃이 과열되고 있군.", "asset": ["emoji-fire"] }
+        {
+          "message": "또다시 네 불꽃이 과열되고 있군.",
+          "asset": [
+            "emoji-fire"
+          ]
+        }
       ],
       [
-        { "message": "이번엔 주변을 태우지 않을 자신 있나?" }
+        {
+          "message": "이번엔 주변을 태우지 않을 자신 있나?"
+        }
+      ],
+      [
+        {
+          "message": "과열? 맞아. 하지만 요즘 너 덕분에 난 온도를 재는 방법도 배우고 있어.",
+          "asset": [
+            "emoji-fire",
+            "emoji-relaxed"
+          ]
+        }
       ]
     ]
   },
@@ -80,10 +172,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "있어. 불꽃을 채널링하는 법을 배웠으니까.", "asset": ["emoji-fire", "emoji-leaf"] }
+        {
+          "message": "있어. 불꽃을 채널링하는 법을 배웠으니까.",
+          "asset": [
+            "emoji-fire",
+            "emoji-leaf"
+          ]
+        }
       ],
       [
-        { "message": "버그 대시보드와 슬랙 봇을 연결해서, 불길이 나기 전에 알람을 울릴 거야." }
+        {
+          "message": "버그 대시보드와 슬랙 봇을 연결해서, 불길이 나기 전에 알람을 울릴 거야."
+        }
+      ],
+      [
+        {
+          "message": "알람이 울리기 전에 커피도 내려두자. 경보 뒤에 웃음이 와야 마음이 진정되거든.",
+          "asset": [
+            "emoji-speech",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -92,10 +201,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "그럼 난 데이터 레이크에서 독자 행동을 분석해서 피드백 루프를 닫아줄게.", "asset": ["emoji-rocket", "emoji-star"] }
+        {
+          "message": "그럼 난 데이터 레이크에서 독자 행동을 분석해서 피드백 루프를 닫아줄게.",
+          "asset": [
+            "emoji-rocket",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "성공 기준을 공유해야 우리가 같은 방향으로 달리지." }
+        {
+          "message": "성공 기준을 공유해야 우리가 같은 방향으로 달리지."
+        }
+      ],
+      [
+        {
+          "message": "독자 데이터 분석 끝나면 우리 동네 빵집 쿠폰도 공유할게. 달콤함이 혁신을 부르지.",
+          "asset": [
+            "emoji-star",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -104,10 +230,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "UX 리서치 일정도 기사〮편집〮배포 흐름에 맞춰 재설계했어요.", "asset": ["emoji-smile", "emoji-sparkle"] }
+        {
+          "message": "UX 리서치 일정도 기사〮편집〮배포 흐름에 맞춰 재설계했어요.",
+          "asset": [
+            "emoji-smile",
+            "emoji-sparkle"
+          ]
+        }
       ],
       [
-        { "message": "이제 모든 스프린트 회의에서 독자 여정 지표를 함께 보게 될 거예요." }
+        {
+          "message": "이제 모든 스프린트 회의에서 독자 여정 지표를 함께 보게 될 거예요."
+        }
+      ],
+      [
+        {
+          "message": "독자 여정 리뷰 끝나면 팟캐스트 추천도 돌릴까요? 이야기 나눌 주제가 많아요.",
+          "asset": [
+            "emoji-speech",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   },
@@ -116,10 +259,26 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "흐음, 이 정도면 언론사가 아니라 기술회사 같군.", "asset": ["emoji-star"] }
+        {
+          "message": "흐음, 이 정도면 언론사가 아니라 기술회사 같군.",
+          "asset": [
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "그래도 방심은 금물이다. 실시간 트래픽은 언제든 폭발해." }
+        {
+          "message": "그래도 방심은 금물이다. 실시간 트래픽은 언제든 폭발해."
+        }
+      ],
+      [
+        {
+          "message": "트래픽 폭발 대비 매뉴얼에 농담 한 줄 넣어둬. 비상시 웃음이 제일 귀하거든.",
+          "asset": [
+            "emoji-bolt",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -128,10 +287,27 @@
     "place": "햄스 요새",
     "sentences": [
       [
-        { "message": "알아. 그래서 시스템이 대신 긴장하도록 만들었어.", "asset": ["emoji-gear", "emoji-muscle"] }
+        {
+          "message": "알아. 그래서 시스템이 대신 긴장하도록 만들었어.",
+          "asset": [
+            "emoji-gear",
+            "emoji-muscle"
+          ]
+        }
       ],
       [
-        { "message": "우리는 서로의 마음을 돌보고, 도구는 위기를 감지하도록." }
+        {
+          "message": "우리는 서로의 마음을 돌보고, 도구는 위기를 감지하도록."
+        }
+      ],
+      [
+        {
+          "message": "오늘 밤엔 기사 대신 별빛을 아카이브하자. 새벽 공기가 우릴 지켜줄 거야.",
+          "asset": [
+            "emoji-sunrise",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   }

--- a/public/chapter5.json
+++ b/public/chapter5.json
@@ -2,16 +2,24 @@
   {
     "sentences": [
       [
-        { "message": "CHAPTER 6 — 그리드의 각성 (자기 성찰과 완성)" }
+        {
+          "message": "CHAPTER 6 — 그리드의 각성 (자기 성찰과 완성)"
+        }
       ],
       [
-        { "message": "배경: 현실과 내면이 교차하는 디지털 심연." }
+        {
+          "message": "배경: 현실과 내면이 교차하는 디지털 심연."
+        }
       ],
       [
-        { "message": "상징: 완성, 균형, 그리고 새로운 시작." }
+        {
+          "message": "상징: 완성, 균형, 그리고 새로운 시작."
+        }
       ],
       [
-        { "message": "키워드: 통합, 회복탄력성, 끝나지 않는 학습." }
+        {
+          "message": "키워드: 통합, 회복탄력성, 끝나지 않는 학습."
+        }
       ]
     ]
   },
@@ -20,10 +28,26 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "이제 마지막이군, 매튜.", "asset": ["emoji-bolt"] }
+        {
+          "message": "이제 마지막이군, 매튜.",
+          "asset": [
+            "emoji-bolt"
+          ]
+        }
       ],
       [
-        { "message": "네가 나를 버리려 드는 순간을 기다렸지." }
+        {
+          "message": "네가 나를 버리려 드는 순간을 기다렸지."
+        }
+      ],
+      [
+        {
+          "message": "마지막이라도 내 농담은 잊지 마. 너를 깨우던 건 비꼼뿐만이 아니었으니까.",
+          "asset": [
+            "emoji-speech",
+            "emoji-bolt"
+          ]
+        }
       ]
     ]
   },
@@ -32,10 +56,27 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "버리지 않아. 넌 내 불안이자 추진력이니까.", "asset": ["emoji-fire", "emoji-leaf"] }
+        {
+          "message": "버리지 않아. 넌 내 불안이자 추진력이니까.",
+          "asset": [
+            "emoji-fire",
+            "emoji-leaf"
+          ]
+        }
       ],
       [
-        { "message": "우린 서로의 언어를 번역해야 해." }
+        {
+          "message": "우린 서로의 언어를 번역해야 해."
+        }
+      ],
+      [
+        {
+          "message": "불안이 덕분에 내가 달리죠. 잠깐 쉬면서 차 한잔하자.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -44,10 +85,26 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "번역? 난 혼자 있을 때 더 빛났어.", "asset": ["emoji-fire"] }
+        {
+          "message": "번역? 난 혼자 있을 때 더 빛났어.",
+          "asset": [
+            "emoji-fire"
+          ]
+        }
       ],
       [
-        { "message": "팀을 믿는다는 네 말, 정말인가?" }
+        {
+          "message": "팀을 믿는다는 네 말, 정말인가?"
+        }
+      ],
+      [
+        {
+          "message": "혼자 빛난다 믿었지만, 요즘은 스탠드 조명이 좋더라. 다들 함께 비추니까.",
+          "asset": [
+            "emoji-star",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -56,10 +113,27 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "정말이야. 나는 더 이상 완벽한 해결사를 연기하지 않아.", "asset": ["emoji-handshake", "emoji-relaxed"] }
+        {
+          "message": "정말이야. 나는 더 이상 완벽한 해결사를 연기하지 않아.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-relaxed"
+          ]
+        }
       ],
       [
-        { "message": "취약함을 공유하는 게 우리를 지탱했어." }
+        {
+          "message": "취약함을 공유하는 게 우리를 지탱했어."
+        }
+      ],
+      [
+        {
+          "message": "취약함을 말한 날 밤엔 만화책도 읽었어. 마음을 가볍게 하는 법을 배우는 중이야.",
+          "asset": [
+            "emoji-speech",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   },
@@ -68,10 +142,27 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "그래, 그게 성숙이야.", "asset": ["emoji-sunrise", "emoji-star"] }
+        {
+          "message": "그래, 그게 성숙이야.",
+          "asset": [
+            "emoji-sunrise",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "리더는 답을 주지 않고 질문을 나눠. 네가 그렇게 변했음을 다들 알고 있어." }
+        {
+          "message": "리더는 답을 주지 않고 질문을 나눠. 네가 그렇게 변했음을 다들 알고 있어."
+        }
+      ],
+      [
+        {
+          "message": "질문 나누기 전에 스트레칭도 잊지 말자. 몸이 편해야 마음이 열린다.",
+          "asset": [
+            "emoji-muscle",
+            "emoji-leaf"
+          ]
+        }
       ]
     ]
   },
@@ -80,10 +171,27 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "최근 회고에서 당신이 먼저 실수를 얘기했을 때 모두가 안도했죠.", "asset": ["emoji-smile", "emoji-speech"] }
+        {
+          "message": "최근 회고에서 당신이 먼저 실수를 얘기했을 때 모두가 안도했죠.",
+          "asset": [
+            "emoji-smile",
+            "emoji-speech"
+          ]
+        }
       ],
       [
-        { "message": "우린 그날 이후 진짜 팀이 됐어요." }
+        {
+          "message": "우린 그날 이후 진짜 팀이 됐어요."
+        }
+      ],
+      [
+        {
+          "message": "회고 끝나고 떡볶이 먹으러 가요. 그날 이후 팀 채팅방 이모지도 더 다양해졌어요.",
+          "asset": [
+            "emoji-fire",
+            "emoji-smile"
+          ]
+        }
       ]
     ]
   },
@@ -92,10 +200,26 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "허허, 이젠 내 잔소리를 기다리는 표정이 아니네.", "asset": ["emoji-star"] }
+        {
+          "message": "허허, 이젠 내 잔소리를 기다리는 표정이 아니네.",
+          "asset": [
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "네가 만든 시스템이 우리를 앞으로 밀어줄 거다." }
+        {
+          "message": "네가 만든 시스템이 우리를 앞으로 밀어줄 거다."
+        }
+      ],
+      [
+        {
+          "message": "시스템 자랑은 내가 대신 해줄게. 너는 오늘만큼은 음악 리스트나 공유해.",
+          "asset": [
+            "emoji-sparkle",
+            "emoji-speech"
+          ]
+        }
       ]
     ]
   },
@@ -104,10 +228,27 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "데이터도 증명했어. 팀 회복 시간, 버그 반응 시간 전부 줄었지.", "asset": ["emoji-rocket", "emoji-gear"] }
+        {
+          "message": "데이터도 증명했어. 팀 회복 시간, 버그 반응 시간 전부 줄었지.",
+          "asset": [
+            "emoji-rocket",
+            "emoji-gear"
+          ]
+        }
       ],
       [
-        { "message": "이젠 새로운 모험을 기획해보자고." }
+        {
+          "message": "이젠 새로운 모험을 기획해보자고."
+        }
+      ],
+      [
+        {
+          "message": "새 모험에는 나침반이 필요하잖아. 데이터 대시보드에 작은 별 아이콘 추가해둘게.",
+          "asset": [
+            "emoji-star",
+            "emoji-rocket"
+          ]
+        }
       ]
     ]
   },
@@ -116,10 +257,26 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "…좋아. 나도 인정하지.", "asset": ["emoji-sparkle"] }
+        {
+          "message": "…좋아. 나도 인정하지.",
+          "asset": [
+            "emoji-sparkle"
+          ]
+        }
       ],
       [
-        { "message": "그릿이라는 이름이 괜히 붙은 게 아니야." }
+        {
+          "message": "그릿이라는 이름이 괜히 붙은 게 아니야."
+        }
+      ],
+      [
+        {
+          "message": "인정하는 김에 우리도 휴가 계획 짜볼까? 쉼도 그릿의 일부라며.",
+          "asset": [
+            "emoji-relaxed",
+            "emoji-sunrise"
+          ]
+        }
       ]
     ]
   },
@@ -128,10 +285,28 @@
     "place": "디지털 심연",
     "sentences": [
       [
-        { "message": "그래, 나는 매튜. 그리고 우리는 함께 계속 나아간다.", "asset": ["emoji-fire", "emoji-handshake", "emoji-star"] }
+        {
+          "message": "그래, 나는 매튜. 그리고 우리는 함께 계속 나아간다.",
+          "asset": [
+            "emoji-fire",
+            "emoji-handshake",
+            "emoji-star"
+          ]
+        }
       ],
       [
-        { "message": "완성은 순간이지만, 지속은 우리의 습관이니까." }
+        {
+          "message": "완성은 순간이지만, 지속은 우리의 습관이니까."
+        }
+      ],
+      [
+        {
+          "message": "다음 장면은 모두 함께 쓰자. 나레이션 대신 합창으로.",
+          "asset": [
+            "emoji-handshake",
+            "emoji-sparkle"
+          ]
+        }
       ]
     ]
   }

--- a/src/components/Sentence.tsx
+++ b/src/components/Sentence.tsx
@@ -1,7 +1,7 @@
 // import reactLogo from './assets/react.svg';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Assets } from '@/Game';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CSSProperties, useEffect, useMemo, useState } from 'react';
 
 // import viteLogo from '/vite.svg';
 interface Sentence {
@@ -19,9 +19,53 @@ export interface SentenceProps {
   data?: string | Sentence | Sentence[];
   isComplete: boolean;
   onComplete: () => void;
+  speakerSide?: 'left' | 'right';
 }
 const defaultDuration = 100;
-const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: SentenceProps) => {
+type AnchorType = 'head' | 'mouth' | 'body' | 'ambient';
+
+interface EmojiMeta {
+  anchor: AnchorType;
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
+  revealAt?: number;
+  delay?: number;
+}
+
+const ANCHOR_POSITIONS: Record<'left' | 'right', Record<AnchorType, CSSProperties>> = {
+  left: {
+    head: { top: '28%', left: '26%' },
+    mouth: { top: '56%', left: '32%' },
+    body: { top: '66%', left: '30%' },
+    ambient: { top: '32%', left: '45%' },
+  },
+  right: {
+    head: { top: '28%', right: '26%' },
+    mouth: { top: '56%', right: '32%' },
+    body: { top: '66%', right: '30%' },
+    ambient: { top: '32%', right: '45%' },
+  },
+};
+
+const EMOJI_META: Record<string, EmojiMeta> = {
+  'emoji-bolt': { anchor: 'head', scale: 1.2, offsetX: -12, offsetY: -24, revealAt: 0.5 },
+  'emoji-fire': { anchor: 'body', scale: 1.25, offsetY: -8, revealAt: 0.55 },
+  'emoji-gear': { anchor: 'body', scale: 1.1, offsetX: -6, revealAt: 0.45 },
+  'emoji-handshake': { anchor: 'body', scale: 1.05, offsetY: 10, revealAt: 0.6 },
+  'emoji-leaf': { anchor: 'ambient', scale: 1, offsetX: 18, offsetY: -6, revealAt: 0.4, delay: 0.1 },
+  'emoji-muscle': { anchor: 'body', scale: 1.1, offsetX: 6, offsetY: 6, revealAt: 0.55 },
+  'emoji-relaxed': { anchor: 'mouth', scale: 1.05, offsetY: 8, revealAt: 0.6 },
+  'emoji-rocket': { anchor: 'ambient', scale: 1.2, offsetX: -30, offsetY: -18, revealAt: 0.45 },
+  'emoji-smile': { anchor: 'mouth', scale: 0.95, offsetY: 4, revealAt: 0.5 },
+  'emoji-sparkle': { anchor: 'ambient', scale: 1.15, offsetX: 8, offsetY: -30, revealAt: 0.4, delay: 0.05 },
+  'emoji-speech': { anchor: 'mouth', scale: 1, offsetX: 14, revealAt: 0.55 },
+  'emoji-star': { anchor: 'ambient', scale: 1.1, offsetX: -18, offsetY: -18, revealAt: 0.45 },
+  'emoji-sunrise': { anchor: 'ambient', scale: 1.05, offsetX: 24, offsetY: 6, revealAt: 0.5 },
+  'emoji-surprised': { anchor: 'mouth', scale: 1.1, offsetY: -2, revealAt: 0.55 },
+};
+
+const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete, speakerSide = 'left' }: SentenceProps) => {
   const [_sentences, setSentences] = useState<Sentence[]>([]);
   const [_cursor, setCursor] = useState<number>(0);
   const [_step, setStep] = useState<number>(-1);
@@ -51,6 +95,13 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
   }, [_sentences, cursor, step, isCompleteProp]);
   const duration = useMemo(() => sentence.duration ?? defaultDuration, [_sentences, step]);
   // const asset = useMemo(() => sentence.asset, [_sentences, step]);
+  const currentSentenceIndex = useMemo(() => {
+    if (_sentences.length === 0) return -1;
+    if (step < 0) return 0;
+    if (step >= _sentences.length) return _sentences.length - 1;
+    return step;
+  }, [_sentences, step]);
+
   const assetArray = useMemo<AssetEntry[]>(() => {
     const entries = _sentences.flatMap((sentence, index) => {
       if (!sentence.asset) return [];
@@ -60,18 +111,14 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
 
     if (isCompleteProp) return entries;
 
-    const currentIndex = Math.min(Math.max(step, 0), _sentences.length - 1);
-    return entries.filter((entry) => entry.index === currentIndex);
-  }, [_sentences, step, isCompleteProp]);
+    if (currentSentenceIndex < 0) return [];
+    return entries.filter((entry) => entry.index <= currentSentenceIndex);
+  }, [_sentences, currentSentenceIndex, isCompleteProp]);
   const isEndCursor = useMemo(() => sentence.message.length <= cursor, [_sentences, step, cursor]);
-  const marginLeft = useCallback(
-    (index: number, arr: AssetEntry[]) => {
-      if (!assets) return 0;
-      const audioLength = arr.slice(index).filter((entry) => assets[entry.name]?.audio).length;
-      return (index - (arr.length - 1) + audioLength) * -100;
-    },
-    [assets],
-  );
+  const revealRatio = useMemo(() => {
+    if (!sentence.message.length) return 1;
+    return Math.min(cursor / sentence.message.length, 1);
+  }, [sentence, cursor]);
   useEffect(() => {
     if (!data) return;
     if (data instanceof Array) setSentences(data);
@@ -96,34 +143,60 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
     <>
       {assets && assetArray && (
         <>
-          {assetArray.map(({ name, key }) => {
-            const asset = assets[name];
-            if (!asset?.audio) return null;
-            return <audio key={`audio-${key}`} src={asset.audio} autoPlay />;
-          })}
-          <AnimatePresence initial={false}>
-            {assetArray.map(({ name, key }, i, arr) => {
-              const asset = assets[name];
-              if (!asset?.image) return null;
-              const offset = marginLeft(i, arr);
-              return (
-                <motion.img
-                  key={`image-${key}`}
-                  className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-x-1/2 -translate-y-1/2 object-contain"
-                  src={asset.image}
-                  alt=""
-                  initial={{ opacity: 0, scale: 0.95, x: offset - 12 }}
-                  animate={{ opacity: 1, scale: 1, x: offset }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{
-                    opacity: { duration: 0.25, ease: 'easeOut' },
-                    scale: { duration: 0.4, ease: 'easeOut' },
-                    x: { type: 'spring', stiffness: 260, damping: 26 },
-                  }}
-                />
-              );
-            })}
-          </AnimatePresence>
+      {assetArray
+        .filter((entry) => entry.index === currentSentenceIndex)
+        .map(({ name, key }) => {
+          const asset = assets?.[name];
+          if (!asset?.audio) return null;
+          return <audio key={`audio-${key}`} src={asset.audio} autoPlay />;
+        })}
+      <AnimatePresence initial={false}>
+        {assetArray.map(({ name, key, index }) => {
+          const asset = assets?.[name];
+          if (!asset?.image) return null;
+          const meta = EMOJI_META[name] ?? { anchor: 'body' };
+          const anchor = ANCHOR_POSITIONS[speakerSide][meta.anchor];
+          if (!anchor) return null;
+          const isPastSentence = index < currentSentenceIndex;
+          const threshold = meta.revealAt ?? 0.65;
+          const shouldShow =
+            isCompleteProp || isPastSentence || (index === currentSentenceIndex && revealRatio >= threshold);
+          if (!shouldShow) return null;
+
+          const size = 96 * (meta.scale ?? 1);
+          const translateX = meta.offsetX ?? 0;
+          const translateY = meta.offsetY ?? 0;
+          const baseTransform = speakerSide === 'right' ? 'translate(50%, -50%)' : 'translate(-50%, -50%)';
+          const style: CSSProperties = {
+            position: 'absolute',
+            pointerEvents: 'none',
+            ...anchor,
+            width: `${size}px`,
+            height: `${size}px`,
+            transform: `${baseTransform} translate(${translateX}px, ${translateY}px)`,
+          };
+
+          const delay = (meta.delay ?? 0) + (isPastSentence ? 0 : 0.05);
+
+          return (
+            <motion.img
+              key={`image-${key}`}
+              className="z-30 select-none object-contain drop-shadow-[0_10px_25px_rgba(0,0,0,0.35)]"
+              style={style}
+              src={asset.image}
+              alt=""
+              initial={{ opacity: 0, scale: 0.92, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.9, y: 12 }}
+              transition={{
+                opacity: { duration: 0.3, ease: 'easeOut', delay },
+                scale: { duration: 0.35, ease: 'easeOut', delay },
+                y: { type: 'spring', stiffness: 180, damping: 20, delay },
+              }}
+            />
+          );
+        })}
+      </AnimatePresence>
         </>
       )}
       <p className="relative flex-auto whitespace-pre-line">

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -42,6 +42,7 @@ const Game = () => {
     () => (direct ? { flexDirection: 'row-reverse' } : { flexDirection: 'row' }),
     [direct],
   );
+  const speakerSide = useMemo<'left' | 'right'>(() => (direct ? 'right' : 'left'), [direct]);
   const handleGoSavePage = () => addStorage({ page: 'save', level });
 
   const handleComplete = () => {
@@ -141,7 +142,13 @@ const Game = () => {
             style={sentencePosition}
           >
             <span className="whitespace-nowrap">{character}</span>
-            <Sentence assets={assets} data={sentence} isComplete={complete} onComplete={handleComplete} />
+            <Sentence
+              assets={assets}
+              data={sentence}
+              isComplete={complete}
+              onComplete={handleComplete}
+              speakerSide={speakerSide}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add directional positioning, sizing, and reveal timing metadata so emoji reactions feel grounded to the speaking character
- pass the current speaker side from the game scene to the sentence renderer to anchor overlays consistently
- extend chapters 1 through 5 with additional conversational beats to deepen characterization and lengthen playtime

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd727a73788331bf591fd1503488db