### PR TITLE
Adjust emoji SVG sizing

### DIFF
--- a/public/assets/emoji-bolt.svg
+++ b/public/assets/emoji-bolt.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">⚡</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">⚡</text>
 </svg>

--- a/public/assets/emoji-fire.svg
+++ b/public/assets/emoji-fire.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🔥</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🔥</text>
 </svg>

--- a/public/assets/emoji-gear.svg
+++ b/public/assets/emoji-gear.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">⚙️</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">⚙️</text>
 </svg>

--- a/public/assets/emoji-handshake.svg
+++ b/public/assets/emoji-handshake.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🤝</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🤝</text>
 </svg>

--- a/public/assets/emoji-leaf.svg
+++ b/public/assets/emoji-leaf.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🌿</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🌿</text>
 </svg>

--- a/public/assets/emoji-muscle.svg
+++ b/public/assets/emoji-muscle.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">💪</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">💪</text>
 </svg>

--- a/public/assets/emoji-relaxed.svg
+++ b/public/assets/emoji-relaxed.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">😌</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">😌</text>
 </svg>

--- a/public/assets/emoji-rocket.svg
+++ b/public/assets/emoji-rocket.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🚀</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🚀</text>
 </svg>

--- a/public/assets/emoji-smile.svg
+++ b/public/assets/emoji-smile.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🙂</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🙂</text>
 </svg>

--- a/public/assets/emoji-sparkle.svg
+++ b/public/assets/emoji-sparkle.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">✨</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">✨</text>
 </svg>

--- a/public/assets/emoji-speech.svg
+++ b/public/assets/emoji-speech.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">💬</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">💬</text>
 </svg>

--- a/public/assets/emoji-star.svg
+++ b/public/assets/emoji-star.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🌟</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🌟</text>
 </svg>

--- a/public/assets/emoji-sunrise.svg
+++ b/public/assets/emoji-sunrise.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">🌅</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">🌅</text>
 </svg>

--- a/public/assets/emoji-surprised.svg
+++ b/public/assets/emoji-surprised.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" rx="24" fill="none"/>
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="72">😲</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96">😲</text>
 </svg>


### PR DESCRIPTION
## Summary
- reduce the viewBox and remove empty rectangles in the emoji SVG assets
- increase the font size so each emoji renders larger within its icon square

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd878551448331bc3ef466b3bb96e0