### PR TITLE
feat: support dynamic scene backgrounds

### DIFF
--- a/public/assets0.json
+++ b/public/assets0.json
@@ -56,6 +56,24 @@
   "별빛 강당": {
     "image": "/assets/bg-6.png"
   },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
+  },
   "emoji-bolt": {
     "image": "/assets/emoji-bolt.svg"
   },

--- a/public/assets1.json
+++ b/public/assets1.json
@@ -97,5 +97,23 @@
   },
   "emoji-surprised": {
     "image": "/assets/emoji-surprised.svg"
+  },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
   }
 }

--- a/public/assets2.json
+++ b/public/assets2.json
@@ -97,5 +97,23 @@
   },
   "emoji-surprised": {
     "image": "/assets/emoji-surprised.svg"
+  },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
   }
 }

--- a/public/assets3.json
+++ b/public/assets3.json
@@ -97,5 +97,23 @@
   },
   "emoji-surprised": {
     "image": "/assets/emoji-surprised.svg"
+  },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
   }
 }

--- a/public/assets4.json
+++ b/public/assets4.json
@@ -97,5 +97,23 @@
   },
   "emoji-surprised": {
     "image": "/assets/emoji-surprised.svg"
+  },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
   }
 }

--- a/public/assets5.json
+++ b/public/assets5.json
@@ -97,5 +97,23 @@
   },
   "emoji-surprised": {
     "image": "/assets/emoji-surprised.svg"
+  },
+  "잊혀진 코드의 나라": {
+    "image": "/assets/bg-1.png"
+  },
+  "세미티에스 공업도시": {
+    "image": "/assets/bg-2.png"
+  },
+  "한국일보 요새": {
+    "image": "/assets/bg-3.png"
+  },
+  "낭비 없는 왕국": {
+    "image": "/assets/bg-4.png"
+  },
+  "Refactor Core": {
+    "image": "/assets/bg-5.png"
+  },
+  "현실 세계": {
+    "image": "/assets/bg-6.png"
   }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -15,6 +15,7 @@ interface Chapter {
   sentences: SentenceProps['data'][];
   character: string;
   place: string;
+  background?: string;
 }
 const Game = () => {
   const { level, addStorage } = useStorageContext();
@@ -26,6 +27,8 @@ const Game = () => {
   const [complete, setComplete] = useState(false);
   const [displayCharacter, setDisplayCharacter] = useState<string>();
   const [characterImage, setCharacterImage] = useState<string>();
+  const [displayPlace, setDisplayPlace] = useState<string>();
+  const [backgroundImage, setBackgroundImage] = useState<string>();
   const assetList = useMemo(
     () => Object.values(assets).flatMap((x) => Object.values(x).filter((x) => x) as string[]),
     [assets],
@@ -42,6 +45,7 @@ const Game = () => {
     () => (direct ? { flexDirection: 'row-reverse' } : { flexDirection: 'row' }),
     [direct],
   );
+  const backgroundKey = useMemo(() => scene?.background ?? scene?.place, [scene]);
   const handleGoSavePage = () => addStorage({ page: 'save', level });
 
   const handleComplete = () => {
@@ -119,10 +123,44 @@ const Game = () => {
     window.addEventListener('keydown', handleEnter);
     return () => window.removeEventListener('keydown', handleEnter);
   }, [complete]);
+  useEffect(() => {
+    if (!backgroundKey) {
+      setDisplayPlace(undefined);
+      setBackgroundImage(undefined);
+      return;
+    }
+    const src = assets[backgroundKey]?.image;
+    if (!src) {
+      setDisplayPlace(undefined);
+      setBackgroundImage(undefined);
+      return;
+    }
+    if (displayPlace === backgroundKey && backgroundImage === src) return;
+    let canceled = false;
+    const img = new Image();
+    img.src = src;
+    const handleLoad = () => {
+      if (canceled) return;
+      setDisplayPlace(backgroundKey);
+      setBackgroundImage(src);
+    };
+    if (img.complete) handleLoad();
+    else img.addEventListener('load', handleLoad, { once: true });
+    return () => {
+      canceled = true;
+      img.removeEventListener('load', handleLoad);
+    };
+  }, [assets, backgroundImage, backgroundKey, displayPlace]);
   // return { character, place, image, Scene, nextScene };
   return (
     <Preload assets={assetList}>
-      <div onClick={nextScene} className="absolute inset-0">
+      <div onClick={nextScene} className="absolute inset-0 overflow-hidden bg-slate-900">
+        <div className="pointer-events-none absolute inset-0">
+          {backgroundImage && displayPlace && (
+            <img className="absolute inset-0 h-full w-full object-cover" src={backgroundImage} alt={displayPlace} />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 opacity-80" />
+        </div>
         {place && assets[place]?.audio && <audio src={assets[place]?.audio} autoPlay />}
         {displayCharacter && characterImage && (
           <img
@@ -131,9 +169,6 @@ const Game = () => {
             src={characterImage}
             alt={displayCharacter}
           />
-        )}
-        {place && assets[place]?.image && (
-          <img className="absolute h-full w-full object-cover" src={assets[place]?.image} alt={place} />
         )}
         {sentence && (
           <div


### PR DESCRIPTION
## Summary
- load and display preloaded scene backgrounds with a consistent fallback gradient during gameplay
- extend each chapter asset manifest with mappings for story locations so backgrounds are available throughout

## Testing
- pnpm lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd8dcafe648331997d0c99c8c9f293