### PR TITLE
Adjust early chapters with dynamic scene backgrounds

### DIFF
--- a/public/chapter0.json
+++ b/public/chapter0.json
@@ -1,5 +1,6 @@
 [
   {
+    "place": "디지털 심연",
     "sentences": [
       [
         {
@@ -423,6 +424,7 @@
     ]
   },
   {
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -434,7 +436,7 @@
   },
   {
     "character": "세라",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -445,7 +447,7 @@
   },
   {
     "character": "엘리",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -456,7 +458,7 @@
   },
   {
     "character": "루크",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -468,7 +470,7 @@
   },
   {
     "character": "그리드",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -480,7 +482,7 @@
   },
   {
     "character": "매튜",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -492,7 +494,7 @@
   },
   {
     "character": "세라",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -504,7 +506,7 @@
   },
   {
     "character": "루크",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -515,7 +517,7 @@
   },
   {
     "character": "엘리",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -527,7 +529,7 @@
   },
   {
     "character": "매튜",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -538,7 +540,7 @@
   },
   {
     "character": "그리드",
-    "place": "잊혀진 코드의 나라",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -549,6 +551,7 @@
     ]
   },
   {
+    "place": "디지털 심연",
     "sentences": [
       [
         {

--- a/public/chapter1.json
+++ b/public/chapter1.json
@@ -1,5 +1,6 @@
 [
   {
+    "place": "세미티에스 공업도시",
     "sentences": [
       [
         {
@@ -135,6 +136,7 @@
     ]
   },
   {
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -145,7 +147,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -157,7 +159,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -169,7 +171,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -180,7 +182,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -192,7 +194,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -203,7 +205,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -215,7 +217,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -226,7 +228,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -240,7 +242,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -251,7 +253,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -262,6 +264,7 @@
     ]
   },
   {
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -272,7 +275,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -284,7 +287,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -295,7 +298,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -306,7 +309,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -318,7 +321,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -329,7 +332,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -341,7 +344,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -352,7 +355,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -366,6 +369,7 @@
     ]
   },
   {
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -376,7 +380,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -387,7 +391,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -398,7 +402,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -410,7 +414,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -421,7 +425,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -432,7 +436,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -443,7 +447,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -454,7 +458,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -465,6 +469,7 @@
     ]
   },
   {
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -475,7 +480,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -486,7 +491,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -497,7 +502,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -508,7 +513,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -520,7 +525,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -535,7 +540,7 @@
   },
   {
     "character": "그리드",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -550,7 +555,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -562,7 +567,7 @@
   },
   {
     "character": "그리드",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -573,7 +578,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -584,7 +589,7 @@
   },
   {
     "character": "그리드",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -596,7 +601,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -608,7 +613,7 @@
   },
   {
     "character": "그리드",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -623,7 +628,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -634,6 +639,7 @@
     ]
   },
   {
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -644,7 +650,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -655,7 +661,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -666,7 +672,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -677,7 +683,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -689,7 +695,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -700,7 +706,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "황혼 격납고",
     "sentences": [
       [
         {
@@ -710,6 +716,7 @@
     ]
   },
   {
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -719,6 +726,7 @@
     ]
   },
   {
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -728,6 +736,7 @@
     ]
   },
   {
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -738,7 +747,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -750,7 +759,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -761,7 +770,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -772,7 +781,7 @@
   },
   {
     "character": "해리",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -783,7 +792,7 @@
   },
   {
     "character": "그리드",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -795,7 +804,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -810,7 +819,7 @@
   },
   {
     "character": "세라",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -822,7 +831,7 @@
   },
   {
     "character": "루크",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -834,7 +843,7 @@
   },
   {
     "character": "엘리",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -846,7 +855,7 @@
   },
   {
     "character": "매튜",
-    "place": "세미티에스 공업도시",
+    "place": "Refactor Core",
     "sentences": [
       [
         {
@@ -860,6 +869,7 @@
     ]
   },
   {
+    "place": "세미티에스 공업도시",
     "sentences": [
       [
         {


### PR DESCRIPTION
## Summary
- Stage the prologue of chapter 0 inside "디지털 심연", move the climax into the "Refactor Core", and fade back into darkness to mirror the story beats.
- Give chapter 1 distinct locations for the alarmed operations floor and the rebuild sequence so the backdrop follows the crisis and dawn resolution.

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd902733848331af0611b4f3f8ce22