### PR TITLE
Fix sentence asset centering

### DIFF
--- a/src/components/Sentence.tsx
+++ b/src/components/Sentence.tsx
@@ -109,7 +109,7 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
               return (
                 <motion.img
                   key={`image-${key}`}
-                  className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-1/2 object-contain"
+                  className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-x-1/2 -translate-y-1/2 transform object-contain"
                   src={asset.image}
                   alt=""
                   initial={{ opacity: 0, scale: 0.95, x: offset - 12 }}


### PR DESCRIPTION
## Summary
- replace the invalid Tailwind translation utility with axis-specific translations so sentence assets are centered correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd9774ad2883319d08c045bbfdf216