### PR TITLE
Center sentence asset images with wrapper

### DIFF
--- a/src/components/Sentence.tsx
+++ b/src/components/Sentence.tsx
@@ -107,20 +107,24 @@ const Sentence = ({ assets, data, isComplete: isCompleteProp, onComplete }: Sent
               if (!asset?.image) return null;
               const offset = marginLeft(i, arr);
               return (
-                <motion.img
+                <div
                   key={`image-${key}`}
-                  className="fixed left-1/2 top-1/2 max-h-40 max-w-40 -translate-x-1/2 -translate-y-1/2 transform object-contain"
-                  src={asset.image}
-                  alt=""
-                  initial={{ opacity: 0, scale: 0.95, x: offset - 12 }}
-                  animate={{ opacity: 1, scale: 1, x: offset }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{
-                    opacity: { duration: 0.25, ease: 'easeOut' },
-                    scale: { duration: 0.4, ease: 'easeOut' },
-                    x: { type: 'spring', stiffness: 260, damping: 26 },
-                  }}
-                />
+                  className="pointer-events-none fixed inset-0 flex items-center justify-center"
+                >
+                  <motion.img
+                    className="max-h-40 max-w-40 object-contain"
+                    src={asset.image}
+                    alt=""
+                    initial={{ opacity: 0, scale: 0.95, x: offset - 12 }}
+                    animate={{ opacity: 1, scale: 1, x: offset }}
+                    exit={{ opacity: 0, scale: 0.95 }}
+                    transition={{
+                      opacity: { duration: 0.25, ease: 'easeOut' },
+                      scale: { duration: 0.4, ease: 'easeOut' },
+                      x: { type: 'spring', stiffness: 260, damping: 26 },
+                    }}
+                  />
+                </div>
               );
             })}
           </AnimatePresence>


### PR DESCRIPTION
## Summary
- wrap sentence asset images in a centered wrapper so motion transforms no longer override Tailwind centering
- keep the motion image animation while relying on the wrapper for layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd98a8ba3c8331b7dc3b077bbec048