### PR TITLE
Reduce preload spinner size

### DIFF
--- a/src/components/Preload.tsx
+++ b/src/components/Preload.tsx
@@ -33,8 +33,8 @@ const Preload = ({ assets, children }: PreloadProps) => {
       {children}
     </motion.div>
   ) : (
-    <div className="h-full w-full">
-      <svg className="h-full w-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <div className="flex h-full w-full items-center justify-center">
+      <svg className="h-24 w-24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
         <circle fill="#FFFFFF" stroke="#FFFFFF" strokeWidth="15" r="15" cx="40" cy="65">
           <animate
             attributeName="cy"


### PR DESCRIPTION
## Summary
- shrink the preload spinner SVG and center it within the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fda5927d348331ad544b5463b2b0df