### PR TITLE
feat: replace favicon with custom visual novel icon

### DIFF
--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,1 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--logos" width="31.88" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 257"><defs><linearGradient id="IconifyId1813088fe1fbc01fb466" x1="-.828%" x2="57.636%" y1="7.652%" y2="78.411%"><stop offset="0%" stop-color="#41D1FF"></stop><stop offset="100%" stop-color="#BD34FE"></stop></linearGradient><linearGradient id="IconifyId1813088fe1fbc01fb467" x1="43.376%" x2="50.316%" y1="2.242%" y2="89.03%"><stop offset="0%" stop-color="#FFEA83"></stop><stop offset="8.333%" stop-color="#FFDD35"></stop><stop offset="100%" stop-color="#FFA800"></stop></linearGradient></defs><path fill="url(#IconifyId1813088fe1fbc01fb466)" d="M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62Z"></path><path fill="url(#IconifyId1813088fe1fbc01fb467)" d="M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113Z"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Visual novel favicon">
+  <defs>
+    <linearGradient id="bg" x1="12" x2="52" y1="8" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff9ad9" />
+      <stop offset="1" stop-color="#715bff" />
+    </linearGradient>
+    <linearGradient id="page" x1="20" x2="44" y1="16" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff" />
+      <stop offset="1" stop-color="#f3e7ff" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <path d="M18 18h10a6 6 0 0 1 6 6v22l-8-3-10 3V20a2 2 0 0 1 2-2Z" fill="url(#page)" />
+  <path d="M46 18H36a6 6 0 0 0-6 6v22l8-3 10 3V20a2 2 0 0 0-2-2Z" fill="url(#page)" />
+  <path d="M20 20v24l10-3.2c.6-.2 1.2-.2 1.8 0L42 44V20" fill="none" stroke="#c9b5ff" stroke-width="2" stroke-linejoin="round" />
+  <path d="M32 24c2.4-2.7 7.4-2.2 8.2 1.7.5 2.5-1.2 4.8-3.6 6.8-1.5 1.2-3 2.3-4.6 3.4-1.6-1.1-3.1-2.2-4.6-3.4-2.4-2-4.1-4.3-3.6-6.8.8-3.9 5.8-4.4 8.2-1.7Z" fill="#ff5f9a" />
+  <path d="M22 15c6.8-3 13.2-3 20 0" fill="none" stroke="#ffd6f2" stroke-width="2.5" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## Summary
- replace the default Vite favicon with a custom visual novel themed SVG

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68feb45ad0e8833189d644cf24ee44b5