### PR TITLE
Adjust start menu inset

### DIFF
--- a/src/pages/StartMenu.tsx
+++ b/src/pages/StartMenu.tsx
@@ -26,7 +26,7 @@ const StartMenuPage = () => {
       <audio src={asset.audio} autoPlay />
       <div className="relative h-full text-white">
         <img className="h-full w-full object-contain" src={asset.image} alt="시작화면" />
-        <div className="absolute inset-0 bottom-auto m-auto flex w-3/5 flex-col gap-3 pb-10">
+        <div className="absolute inset-4 bottom-auto m-auto flex w-3/5 flex-col gap-3 pb-10">
           <Btn autoFocus onClick={handleStart}>
             시작하기
           </Btn>


### PR DESCRIPTION
## Summary
- adjust the start menu button container to use `inset-4` for better spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff0bb6b0648331aa7799678b6befee