### PR TITLE
Enhance chapter transition screen design

### DIFF
--- a/src/pages/Save.tsx
+++ b/src/pages/Save.tsx
@@ -26,17 +26,29 @@ const SavePage = () => {
   };
   return (
     <motion.div
-      className="relative flex h-full w-full items-center border text-white"
+      className="relative flex h-full w-full items-center justify-center overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-white"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
     >
-      <div className="flex w-full flex-col items-center gap-3 p-5">
-        <h1 className="text-center">챕터{chapterNumber} 끝</h1>
-        <Btn onClick={handleSave}>저장</Btn>
-        <Btn autoFocus onClick={handleGame}>
-          바로 시작
-        </Btn>
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-emerald-400/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-56 w-56 translate-x-16 translate-y-16 rounded-full bg-emerald-500/10 blur-3xl" />
+      </div>
+      <div className="relative flex w-full max-w-md flex-col items-center gap-6 rounded-2xl border border-white/10 bg-white/5 p-8 text-center shadow-2xl backdrop-blur">
+        <span className="text-sm uppercase tracking-[0.35em] text-emerald-200">Chapter {chapterNumber}</span>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold text-white">챕터 {chapterNumber} 종료</h1>
+          <p className="text-sm text-slate-200/80">
+            이어지는 이야기를 저장하거나 바로 다음 장을 시작해 보세요.
+          </p>
+        </div>
+        <div className="flex w-full flex-col gap-3">
+          <Btn onClick={handleSave}>진행 상황 저장</Btn>
+          <Btn autoFocus onClick={handleGame}>
+            다음 챕터로 이동
+          </Btn>
+        </div>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- refresh the chapter-complete screen with a soft gradient background and glassmorphism card
- add contextual copy and clearer button labels for saving or moving to the next chapter

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690317b94d8483318bfa2865a590db71