### PR TITLE
Reduce auto advance delay

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -275,10 +275,10 @@ const Game = () => {
 
   const autoAdvanceDelay = useMemo(() => {
     const entries = parseSentenceData(sentenceData);
-    if (!entries.length) return 1800;
+    if (!entries.length) return 500;
     const typingTime = entries.reduce((total, entry) => total + entry.message.length * entry.duration, 0);
     const buffer = entries.reduce((total, entry) => total + entry.message.length * 20, 0);
-    return Math.max(1800, Math.min(5000, Math.round(typingTime * 0.5 + buffer)));
+    return Math.max(500, Math.min(5000, Math.round(typingTime * 0.5 + buffer)));
   }, [parseSentenceData, sentenceData]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- lower the default auto-advance delay to 500ms when no sentence data is present
- reduce the minimum auto-advance threshold to 500ms so auto click progresses faster

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903564b97d083318fb1c6d95360f436