### PR TITLE
Tune emotional assets in chapter scripts

### DIFF
--- a/public/chapter0.json
+++ b/public/chapter0.json
@@ -17,7 +17,7 @@
       [
         {
           "message": "(숨을 내쉬며) …여긴… 어디야?",
-          "asset": "emoji-relaxed",
+          "asset": "emoji-surprised",
           "duration": 185
         },
         {
@@ -140,7 +140,6 @@
         },
         {
           "message": "이름은… 그리드(Grit).",
-          "asset": "emoji-star",
           "duration": 130
         }
       ]
@@ -176,7 +175,6 @@
         },
         {
           "message": "그때 넌 ‘시간이 없었다’고 말했잖아.",
-          "asset": "emoji-speech",
           "duration": 100
         }
       ]
@@ -189,7 +187,6 @@
       [
         {
           "message": "시간은 언제나 없었지.",
-          "asset": "emoji-sunrise",
           "duration": 125
         },
         {
@@ -286,7 +283,7 @@
       [
         {
           "message": "(쓴웃음) 그때 네가 말했잖아. \"매튜, 사람은 코드보다 불완전해야 아름다워.\" 근데 난 그 말을 무시했어.",
-          "asset": "emoji-smile",
+          "asset": "emoji-leaf",
           "duration": 140
         }
       ]
@@ -453,7 +450,7 @@
       [
         {
           "message": "(팔짱을 끼며) 둘이 만나면 늘 이 모양이지. 코드보다 대사가 더 길어.",
-          "asset": "emoji-muscle",
+          "asset": "emoji-smile",
           "duration": 80
         }
       ]
@@ -789,7 +786,7 @@
       [
         {
           "message": "(조용히 사라지며) 그럼, 나도 기다리마. 너의 다음 리빌드가… 실패하지 않기를.",
-          "asset": "emoji-sunrise",
+          "asset": "emoji-sparkle",
           "duration": 160
         }
       ]

--- a/public/chapter1.json
+++ b/public/chapter1.json
@@ -21,7 +21,7 @@
       [
         {
           "message": "(손에 커피를 들고) 또… 밤샜군, 매튜.",
-          "asset": "emoji-handshake",
+          "asset": "emoji-relaxed",
           "duration": 135
         }
       ]
@@ -72,7 +72,7 @@
       [
         {
           "message": "(책상에 턱을 괴며) 완성이 아니라 집착이겠지.",
-          "asset": "emoji-star",
+          "asset": "emoji-relaxed",
           "duration": 110
         },
         {
@@ -90,12 +90,10 @@
       [
         {
           "message": "…시간 아깝잖아.",
-          "asset": "emoji-sunrise",
           "duration": 135
         },
         {
           "message": "코드는 기다려주지 않아.",
-          "asset": "emoji-gear",
           "duration": 90
         }
       ]
@@ -121,7 +119,7 @@
       [
         {
           "message": "(뒤에서 천천히 등장) 멈추는 것도 기술이지.",
-          "asset": "emoji-rocket",
+          "asset": "emoji-sparkle",
           "duration": 85
         },
         {
@@ -131,7 +129,6 @@
         },
         {
           "message": "잠깐 꺼줘야 타오르지.",
-          "asset": "emoji-sparkle",
           "duration": 125
         }
       ]
@@ -144,7 +141,7 @@
       [
         {
           "message": "(고개를 들며) 나한테 집중은… 숨쉬는 거야.",
-          "asset": "emoji-rocket",
+          "asset": "emoji-fire",
           "duration": 90
         }
       ],
@@ -237,7 +234,7 @@
       [
         {
           "message": "(문을 박차고 들어오며) 얘들아, 또 터졌냐?!",
-          "asset": "emoji-star",
+          "asset": "emoji-bolt",
           "duration": 90
         }
       ]
@@ -250,7 +247,7 @@
       [
         {
           "message": "(귀를 막으며) 사운드 이펙트 좀 낮춰줘요, 길드장님.",
-          "asset": "emoji-star",
+          "asset": "emoji-relaxed",
           "duration": 110
         }
       ]
@@ -281,7 +278,7 @@
       [
         {
           "message": "(화면을 보며) 프록시 서버가 버티질 못해요. 세 개가 이미 다운됐어요.",
-          "asset": "emoji-star",
+          "asset": "emoji-gear",
           "duration": 110
         }
       ]
@@ -306,7 +303,7 @@
       [
         {
           "message": "(조용히) …구조가 문제야.",
-          "asset": "emoji-sunrise",
+          "asset": "emoji-gear",
           "duration": 160
         }
       ]
@@ -383,7 +380,7 @@
       [
         {
           "message": "(조용히) …그 말, 멋지네.",
-          "asset": "emoji-sunrise",
+          "asset": "emoji-smile",
           "duration": 160
         }
       ]
@@ -420,7 +417,7 @@
       [
         {
           "message": "(손가락을 두드리며) …좋아, 해봐. 대신 네 이름 걸고.",
-          "asset": "emoji-muscle",
+          "asset": "emoji-bolt",
           "duration": 100
         }
       ]
@@ -445,7 +442,7 @@
       [
         {
           "message": "(고개를 저으며) 이건 자폭이야.",
-          "asset": "emoji-star",
+          "asset": "emoji-fire",
           "duration": 110
         }
       ]
@@ -522,7 +519,7 @@
       [
         {
           "message": "(눈을 좁히며) 저건… 네가 직접 짠 빌드 엔진인가?",
-          "asset": "emoji-star",
+          "asset": "emoji-gear",
           "duration": 125
         }
       ]
@@ -673,7 +670,7 @@
       [
         {
           "message": "(어둠 속에서 천천히 등장) 또 불을 붙였군, 매튜.",
-          "asset": "emoji-rocket",
+          "asset": "emoji-sparkle",
           "duration": 85
         },
         {
@@ -690,7 +687,7 @@
       [
         {
           "message": "(고개를 돌리며) 그리드… 네가 여기까지 따라왔군.",
-          "asset": "emoji-star",
+          "asset": "emoji-surprised",
           "duration": 130
         }
       ]
@@ -790,7 +787,7 @@
       [
         {
           "message": "(비웃음) 모든 불은 처음엔 빛이었지. 하지만 결국, 연기로 변하더군.",
-          "asset": "emoji-smile",
+          "asset": "emoji-fire",
           "duration": 120
         }
       ]
@@ -803,7 +800,7 @@
       [
         {
           "message": "(조용히) …그리드. 넌 그의 과거인가?",
-          "asset": "emoji-sunrise",
+          "asset": "emoji-gear",
           "duration": 155
         }
       ]
@@ -833,7 +830,7 @@
       [
         {
           "message": "(나직하게) 그럼 인간이면 어때? 불완전해야 아름답다니까.",
-          "asset": "emoji-star",
+          "asset": "emoji-sunrise",
           "duration": 105
         }
       ]
@@ -963,7 +960,7 @@
       [
         {
           "message": "(놀란 듯) …돌아왔다.",
-          "asset": "emoji-star",
+          "asset": "emoji-surprised",
           "duration": 130
         }
       ]
@@ -1025,7 +1022,7 @@
       [
         {
           "message": "(피곤한 얼굴로 고개를 들며) 괜찮아. 불씨는 남아있어야 해.",
-          "asset": "emoji-rocket",
+          "asset": "emoji-relaxed",
           "duration": 70
         },
         {

--- a/public/chapter2.json
+++ b/public/chapter2.json
@@ -119,7 +119,6 @@
         },
         {
           "message": "시스템 로그 전체에 ‘MATTHEW_ORIGIN’이라고.",
-          "asset": "emoji-gear",
           "duration": 80
         }
       ]
@@ -211,7 +210,7 @@
       [
         {
           "message": "(한 걸음 앞으로 나서며) 그럼… 그들이 살아 있다는 거군.",
-          "asset": "emoji-star",
+          "asset": "emoji-surprised",
           "duration": 130
         }
       ],
@@ -395,7 +394,7 @@
       [
         {
           "message": "(한숨) 그리드가 말했잖아.\n불은 빛을 주지만, 결국 자신을 태운다고.\n그 불이 이 도시에 남은 거야.",
-          "asset": "emoji-relaxed",
+          "asset": "emoji-leaf",
           "duration": 160
         }
       ]
@@ -569,7 +568,7 @@
       [
         {
           "message": "(뒤로 물러서며) 그리드가 도시 전체를 흡수하고 있어!",
-          "asset": "emoji-star",
+          "asset": "emoji-bolt",
           "duration": 95
         }
       ]
@@ -618,7 +617,7 @@
       [
         {
           "message": "(격한 숨소리) 알아… 하지만!\n그 감정이 날 만든 거야.\n이젠 도망치지 않겠어!",
-          "asset": "emoji-star",
+          "asset": "emoji-fire",
           "duration": 100
         }
       ]

--- a/public/chapter3.json
+++ b/public/chapter3.json
@@ -111,7 +111,7 @@
       [
         {
           "message": "(성문을 밀치며 등장) 좋은 철학이군.",
-          "asset": "emoji-rocket",
+          "asset": "emoji-bolt",
           "duration": 70
         },
         {
@@ -223,7 +223,7 @@
       [
         {
           "message": "(한숨) 매튜, 그 표정… 또 그때처럼이네. 불타는 눈빛. 모두를 구하겠다는 그 무모한 완벽주의.",
-          "asset": "emoji-relaxed",
+          "asset": "emoji-leaf",
           "duration": 180
         }
       ]
@@ -284,7 +284,7 @@
       [
         {
           "message": "(입꼬리를 올리며) 좋아, 스타트업 길드가 다시 뭉쳤군. 이제 남은 건—리더의 명령뿐이지.",
-          "asset": "emoji-star",
+          "asset": "emoji-smile",
           "duration": 110
         }
       ]
@@ -612,7 +612,7 @@
       [
         {
           "message": "(어깨를 툭 치며) 이번엔 진짜 끝난 거지?",
-          "asset": "emoji-star",
+          "asset": "emoji-smile",
           "duration": 105
         }
       ]

--- a/public/chapter4.json
+++ b/public/chapter4.json
@@ -35,7 +35,7 @@
       [
         {
           "message": "(황폐한 탑을 보며) …아무것도 없어서 ‘낭비가 없다’는 뜻 아닐까?",
-          "asset": "emoji-star",
+          "asset": "emoji-leaf",
           "duration": 110
         }
       ]
@@ -48,7 +48,7 @@
       [
         {
           "message": "(손을 허공에 내밀며) 아니, 여긴 완전한 시스템이었어. 과거엔 데이터가 손실도 없었고, 모든 프로세스가 완벽하게 순환했지. 문제는… ‘변화가 사라졌다는 것’이야.",
-          "asset": "emoji-handshake",
+          "asset": "emoji-gear",
           "duration": 170
         }
       ]
@@ -152,7 +152,7 @@
       [
         {
           "message": "(작게 웃으며) 그러니까 여긴… 매튜가 만든 ‘지옥’이네. 완벽함의 지옥.",
-          "asset": "emoji-smile",
+          "asset": "emoji-leaf",
           "duration": 140
         }
       ]
@@ -392,7 +392,7 @@
       [
         {
           "message": "(짙은 그림자 속에서 나타나며) 또다시 자신을 희생하겠다고? 넌 불타야만 깨닫는 건가?",
-          "asset": "emoji-rocket",
+          "asset": "emoji-fire",
           "duration": 60
         }
       ]
@@ -527,7 +527,7 @@
       [
         {
           "message": "(왕국 위로 햇살이 비친다. 부서진 탑이 서서히 정렬되고, 코드들이 따뜻한 색으로 빛난다.)",
-          "asset": "emoji-gear",
+          "asset": "emoji-sunrise",
           "duration": 140
         }
       ]

--- a/public/chapter5.json
+++ b/public/chapter5.json
@@ -26,7 +26,7 @@
       [
         {
           "message": "(조용히 눈을 뜨며) 여긴… 아무 소리도 없네.",
-          "asset": "emoji-star",
+          "asset": "emoji-sunrise",
           "duration": 145
         }
       ],
@@ -652,7 +652,7 @@
       [
         {
           "message": "(공간이 천천히 해체되며, 매튜가 현실로 돌아온다. 그의 눈빛은 더 이상 불타지 않는다. 대신 따뜻하게 빛난다.)",
-          "asset": "emoji-fire",
+          "asset": "emoji-sunrise",
           "duration": 130
         }
       ]


### PR DESCRIPTION
## Summary
- restore expression assets to emotional lines across chapters 0-5 while keeping neutral dialogue free of cues
- retune mismatched asset selections so each scene’s emoji better reflects the underlying tone

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_69043cbdcce88331bf9a03770d04004c