### PR TITLE
Improve auto progression speed and indicator visibility

### DIFF
--- a/src/components/Sentence.tsx
+++ b/src/components/Sentence.tsx
@@ -23,7 +23,7 @@ export interface SentenceProps {
   autoProgress?: number;
   onComplete: () => void;
 }
-const defaultDuration = 100;
+const defaultDuration = 70;
 const Sentence = ({ assets, data, direct, isComplete: isCompleteProp, auto, autoProgress, onComplete }: SentenceProps) => {
   const [_sentences, setSentences] = useState<Sentence[]>([]);
   const [_cursor, setCursor] = useState<number>(0);
@@ -146,35 +146,41 @@ const Sentence = ({ assets, data, direct, isComplete: isCompleteProp, auto, auto
           </AnimatePresence>
         </>
       )}
-      <p className="relative flex-auto whitespace-pre-line">
-        {sentences}
-        {isComplete ? (
-          <span className="ml-auto block w-fit animate-pulse">
-            <span className="relative inline-flex h-8 w-8 items-center justify-center">
-              {showAutoProgress && (
-                <>
-                  <span className="absolute inset-0 rounded-full" style={gaugeStyle} />
-                  <span className="absolute inset-[3px] rounded-full bg-white/80" />
-                </>
-              )}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
-                className="h-6 w-6"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="m15 15 6-6m0 0-6-6m6 6H9a6 6 0 0 0 0 12h3" />
-              </svg>
+      <div className="relative flex flex-auto items-end gap-4">
+        <span className="flex-1 whitespace-pre-line leading-relaxed">
+          {sentences}
+          {!isComplete && (
+            <span className="ml-1 inline-block animate-ping align-baseline" style={{ animationDuration: `${duration}ms` }}>
+              |
             </span>
-          </span>
-        ) : (
-          <span className="animate-ping" style={{ animationDuration: `${duration}ms` }}>
-            |
-          </span>
-        )}
-      </p>
+          )}
+        </span>
+        <span
+          className={`relative inline-flex h-10 w-10 items-center justify-center transition-opacity ${
+            isCompleteProp ? 'opacity-100 animate-pulse' : 'opacity-60'
+          }`}
+        >
+          {showAutoProgress && (
+            <>
+              <span className="absolute inset-0 rounded-full" style={gaugeStyle} />
+              <span className="absolute inset-[3px] rounded-full bg-white/80" />
+            </>
+          )}
+          {!showAutoProgress && (
+            <span className="absolute inset-0 rounded-full bg-white/60" />
+          )}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="relative h-6 w-6"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="m15 15 6-6m0 0-6-6m6 6H9a6 6 0 0 0 0 12h3" />
+          </svg>
+        </span>
+      </div>
     </>
   );
 };

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -244,7 +244,7 @@ const Game = () => {
 
   const parseSentenceData = useCallback((data: SentenceProps['data'] | undefined) => {
     if (!data) return [] as { message: string; duration: number }[];
-    const defaultDuration = 100;
+    const defaultDuration = 70;
     const normalise = (entry: string | SentenceObject) => {
       if (typeof entry === 'string') {
         return { message: entry, duration: defaultDuration };
@@ -271,9 +271,16 @@ const Game = () => {
     const entries = parseSentenceData(sentenceData);
     if (!entries.length) return 500;
     const typingTime = entries.reduce((total, entry) => total + entry.message.length * entry.duration, 0);
-    const buffer = entries.reduce((total, entry) => total + entry.message.length * 20, 0);
-    return Math.max(500, Math.min(5000, Math.round(typingTime * 0.5 + buffer)));
+    const buffer = entries.reduce((total, entry) => total + entry.message.length * 12, 0);
+    return Math.max(350, Math.min(4000, Math.round(typingTime * 0.4 + buffer)));
   }, [parseSentenceData, sentenceData]);
+
+  useEffect(() => {
+    if (!auto) return;
+    if (!complete || activeChoice) return;
+    setAutoProgress(0);
+    setCompletedAt(Date.now());
+  }, [auto, complete, activeChoice]);
 
   useEffect(() => {
     if (!auto || !complete || activeChoice || !completedAt) {


### PR DESCRIPTION
## Summary
- keep the enter indicator visible with dedicated spacing and styling, including a default background when auto mode is disabled
- speed up the typewriter effect and auto-advance timing for snappier pacing
- reset the auto-advance gauge when auto mode is toggled back on so it always starts fresh

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691019e9b0f48331a0eba72bae8582fd)