### PR TITLE
feat: add battle combat flow

### DIFF
--- a/public/chapter0.json
+++ b/public/chapter0.json
@@ -108,7 +108,57 @@
           "duration": 100
         }
       ]
-    ]
+    ],
+    "next": {
+      "id": "refactor-battle"
+    }
+  },
+  {
+    "character": "시스템",
+    "place": "Refactor Core",
+    "sentences": [
+      [
+        {
+          "message": "[경보] Refactor Core에 교란 신호 감지",
+          "duration": 80
+        }
+      ]
+    ],
+    "battle": {
+      "flag": true,
+      "description": "Refactor Core - 긴급 방어 프로토콜",
+      "encounter": "오염된 루틴이 나타났다!",
+      "party": [
+        "매튜",
+        "세라"
+      ],
+      "enemy": {
+        "name": "부패한 루틴",
+        "stats": {
+          "maxHp": 150,
+          "attack": 16,
+          "defense": 8,
+          "speed": 8
+        },
+        "skills": [
+          {
+            "id": "glitch-whip",
+            "name": "글리치 휩",
+            "description": "불안정한 코드 조각을 휘둘러 공격합니다.",
+            "power": 9,
+            "type": "attack"
+          },
+          {
+            "id": "corrupt-wave",
+            "name": "코럽트 웨이브",
+            "description": "오염된 파장을 방출해 파티를 덮칩니다.",
+            "power": 7,
+            "type": "attack"
+          }
+        ]
+      }
+    },
+    "id": "refactor-battle"
   },
   {
     "character": "매튜",

--- a/src/components/Battle.tsx
+++ b/src/components/Battle.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BattleConfig, BattleEnemyConfig, BattleSkill, BattleStats } from '#/novelTypes';
+import { getPartyDefinitions } from '#/battleData';
+
+interface BattleProps {
+  config: BattleConfig;
+  onComplete: (result: 'win' | 'lose') => void;
+}
+
+interface CharacterState {
+  name: string;
+  hp: number;
+  stats: BattleStats;
+  skills: BattleSkill[];
+}
+
+interface EnemyState extends BattleEnemyConfig {
+  hp: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const useBattleLog = (initial: string) => {
+  const [log, setLog] = useState<string[]>([initial]);
+  const pushLog = useCallback((entry: string) => {
+    setLog((prev) => [...prev, entry].slice(-6));
+  }, []);
+  const reset = useCallback((message: string) => setLog([message]), []);
+  return { log, pushLog, reset } as const;
+};
+
+const Battle = ({ config, onComplete }: BattleProps) => {
+  const partyDefinitions = useMemo(() => getPartyDefinitions(config.party), [config.party]);
+  const [players, setPlayers] = useState<CharacterState[]>(() =>
+    partyDefinitions.map((character) => ({
+      name: character.name,
+      stats: character.stats,
+      skills: character.skills,
+      hp: character.stats.maxHp,
+    })),
+  );
+  const [enemy, setEnemy] = useState<EnemyState>({
+    ...config.enemy,
+    hp: config.enemy.stats.maxHp,
+  });
+  const [turn, setTurn] = useState<'player' | 'enemy'>('player');
+  const { log, pushLog, reset: resetLog } = useBattleLog(config.encounter ?? `${config.enemy.name} 이(가) 나타났다!`);
+
+  useEffect(() => {
+    setPlayers(
+      partyDefinitions.map((character) => ({
+        name: character.name,
+        stats: character.stats,
+        skills: character.skills,
+        hp: character.stats.maxHp,
+      })),
+    );
+    setEnemy({ ...config.enemy, hp: config.enemy.stats.maxHp });
+    setTurn('player');
+    resetLog(config.encounter ?? `${config.enemy.name} 이(가) 나타났다!`);
+  }, [config, config.enemy, config.encounter, partyDefinitions, resetLog]);
+
+  const activePlayerIndex = useMemo(() => players.findIndex((character) => character.hp > 0), [players]);
+  const activePlayer = activePlayerIndex >= 0 ? players[activePlayerIndex] : undefined;
+
+  const calculateDamage = useCallback(
+    (attackerAttack: number, skillPower: number, targetDefense: number) => Math.max(1, attackerAttack + skillPower - targetDefense),
+    [],
+  );
+
+  const handlePlayerSkill = useCallback(
+    (skill: BattleSkill) => {
+      if (!activePlayer || turn !== 'player') return;
+
+      if (skill.type === 'heal') {
+        setPlayers((prev) =>
+          prev.map((character, index) => {
+            if (index !== activePlayerIndex) return character;
+            const nextHp = clamp(character.hp + skill.power, 0, character.stats.maxHp);
+            if (nextHp !== character.hp) {
+              pushLog(`${character.name}이 ${skill.name}으로 ${nextHp - character.hp} 회복!`);
+            }
+            return { ...character, hp: nextHp };
+          }),
+        );
+        setTurn('enemy');
+        return;
+      }
+
+      setEnemy((prev) => {
+        const damage = calculateDamage(activePlayer.stats.attack, skill.power, prev.stats.defense);
+        const nextHp = clamp(prev.hp - damage, 0, prev.stats.maxHp);
+        pushLog(`${activePlayer.name}의 ${skill.name}! ${prev.name}에게 ${damage} 피해.`);
+        return { ...prev, hp: nextHp };
+      });
+      setTurn('enemy');
+    },
+    [activePlayer, turn, activePlayerIndex, pushLog, calculateDamage],
+  );
+
+  useEffect(() => {
+    if (turn !== 'enemy') return;
+    if (enemy.hp <= 0) return;
+
+    const timeout = window.setTimeout(() => {
+      setPlayers((prev) => {
+        const alive = prev.filter((character) => character.hp > 0);
+        if (!alive.length) return prev;
+        const target = alive[Math.floor(Math.random() * alive.length)];
+        const targetIndex = prev.findIndex((character) => character.name === target.name);
+        const skillList = enemy.skills ?? [{ id: 'enemy-strike', name: '글리치 스트라이크', description: '', power: 6, type: 'attack' }];
+        const skill = skillList[Math.floor(Math.random() * skillList.length)];
+        const damage = calculateDamage(enemy.stats.attack, skill.power, target.stats.defense);
+        pushLog(`${enemy.name}의 ${skill.name}! ${target.name}이 ${damage} 피해.`);
+        return prev.map((character, index) =>
+          index === targetIndex ? { ...character, hp: clamp(character.hp - damage, 0, character.stats.maxHp) } : character,
+        );
+      });
+      setTurn('player');
+    }, 650);
+
+    return () => window.clearTimeout(timeout);
+  }, [turn, enemy, pushLog, calculateDamage]);
+
+  useEffect(() => {
+    if (enemy.hp > 0) return;
+    const timeout = window.setTimeout(() => onComplete('win'), 600);
+    return () => window.clearTimeout(timeout);
+  }, [enemy.hp, onComplete]);
+
+  useEffect(() => {
+    if (players.some((character) => character.hp > 0)) return;
+    const timeout = window.setTimeout(() => onComplete('lose'), 600);
+    return () => window.clearTimeout(timeout);
+  }, [players, onComplete]);
+
+  const enemyHpPercent = Math.round((enemy.hp / enemy.stats.maxHp) * 100);
+
+  return (
+    <div className="flex h-full flex-col justify-between bg-slate-950 text-white">
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-emerald-300">Battle</p>
+          <h2 className="text-2xl font-semibold">{config.description ?? '시스템 교란체를 포착했습니다.'}</h2>
+          <p className="text-sm text-slate-300">
+            {turn === 'player' ? '스킬을 선택하여 공격하세요.' : '적의 행동을 기다리는 중입니다.'}
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase text-slate-400">Enemy</p>
+            <h3 className="text-xl font-semibold">{enemy.name}</h3>
+            <div className="mt-3 h-3 rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-red-400"
+                style={{ width: `${enemyHpPercent}%` }}
+              />
+            </div>
+            <p className="mt-2 text-sm text-slate-300">HP {enemy.hp} / {enemy.stats.maxHp}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+            <p className="text-xs uppercase text-slate-400">Party</p>
+            <div className="mt-2 flex flex-col gap-3">
+              {players.map((character) => {
+                const percent = Math.round((character.hp / character.stats.maxHp) * 100);
+                return (
+                  <div key={character.name} className="rounded-xl border border-white/5 bg-slate-900/60 p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{character.name}</span>
+                      <span className="text-sm text-slate-300">
+                        HP {character.hp} / {character.stats.maxHp}
+                      </span>
+                    </div>
+                    <div className="mt-2 h-2 rounded-full bg-white/10">
+                      <div
+                        className="h-full rounded-full bg-emerald-400"
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <p className="text-xs uppercase text-slate-400">Active Skills</p>
+          {activePlayer ? (
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              {activePlayer.skills.map((skill) => (
+                <button
+                  key={skill.id}
+                  className="rounded-xl border border-white/10 bg-slate-900/70 px-4 py-3 text-left text-sm transition hover:border-emerald-300 hover:bg-emerald-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={turn !== 'player' || enemy.hp <= 0}
+                  onClick={() => handlePlayerSkill(skill)}
+                >
+                  <p className="font-semibold">{skill.name}</p>
+                  <p className="text-xs text-slate-300">{skill.description}</p>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-slate-300">행동 가능한 캐릭터가 없습니다.</p>
+          )}
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <p className="text-xs uppercase text-slate-400">Battle Log</p>
+          <ul className="mt-2 space-y-1 text-sm text-slate-200">
+            {log.map((entry, index) => (
+              <li key={`${entry}-${index}`}>{entry}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Battle;

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -4,6 +4,7 @@ import StartMenuPage from '@/StartMenu';
 import GamePage from '@/Game';
 import SavePage from '@/Save';
 import CreditPage from '@/Credit';
+import GameOverPage from '@/GameOver';
 
 const Routes = () => {
   const { page } = useStorageContext();
@@ -16,6 +17,8 @@ const Routes = () => {
       return <SavePage />;
     case 'credit':
       return <CreditPage />;
+    case 'gameOver':
+      return <GameOverPage />;
     default:
       return <SplashPage />;
   }

--- a/src/components/StorageContext.tsx
+++ b/src/components/StorageContext.tsx
@@ -2,7 +2,7 @@ import useSession from '#/useSession';
 import { ReactNode, createContext, useContext } from 'react';
 export interface SessionStorage {
   level: number;
-  page: 'startMenu' | 'game' | 'save' | 'credit';
+  page: 'startMenu' | 'game' | 'save' | 'credit' | 'gameOver';
   inventory: boolean;
 }
 interface StorageProviderProps {

--- a/src/pages/GameOver.tsx
+++ b/src/pages/GameOver.tsx
@@ -1,0 +1,36 @@
+import Btn from '@/Btn';
+import { useStorageContext } from '@/StorageContext';
+import { motion } from 'framer-motion';
+
+const GameOverPage = () => {
+  const { level, addStorage } = useStorageContext();
+  const handleRetry = () => addStorage({ page: 'game', level: level ?? 0 });
+  const handleTitle = () => addStorage({ page: 'startMenu', level: 0 });
+
+  return (
+    <motion.div
+      className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-900 via-slate-950 to-black text-white"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="flex w-full max-w-md flex-col gap-6 rounded-2xl border border-red-400/20 bg-white/5 p-8 text-center shadow-2xl backdrop-blur">
+        <div>
+          <p className="text-sm uppercase tracking-[0.4em] text-red-300">System Halted</p>
+          <h1 className="text-3xl font-bold text-white">게임 오버</h1>
+        </div>
+        <p className="text-sm text-slate-100/80">
+          전투에서 패배했습니다. 장비를 점검하고 다시 도전해 보세요.
+        </p>
+        <div className="flex flex-col gap-3">
+          <Btn onClick={handleRetry}>다시 시도</Btn>
+          <Btn autoFocus onClick={handleTitle}>
+            타이틀로 돌아가기
+          </Btn>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default GameOverPage;

--- a/src/utils/battleData.ts
+++ b/src/utils/battleData.ts
@@ -1,0 +1,106 @@
+import { BattleCharacterDefinition } from '#/novelTypes';
+
+const defaultSkill = {
+  id: 'basic-attack',
+  name: '기본 공격',
+  description: '적을 검으로 베어낸다.',
+  power: 6,
+  type: 'attack' as const,
+};
+
+export const CHARACTER_LIBRARY: Record<string, BattleCharacterDefinition> = {
+  매튜: {
+    name: '매튜',
+    stats: {
+      maxHp: 120,
+      attack: 18,
+      defense: 8,
+      speed: 10,
+    },
+    skills: [
+      {
+        id: 'overclock-strike',
+        name: '오버클럭 스트라이크',
+        description: '코드를 과열시켜 강력한 일격을 날립니다.',
+        power: 12,
+        type: 'attack',
+      },
+      {
+        id: 'refactor-shield',
+        name: '리팩터 쉴드',
+        description: '불완전한 코드를 정리하며 체력을 회복합니다.',
+        power: 10,
+        type: 'heal',
+      },
+    ],
+  },
+  세라: {
+    name: '세라',
+    stats: {
+      maxHp: 100,
+      attack: 16,
+      defense: 10,
+      speed: 12,
+    },
+    skills: [
+      {
+        id: 'data-pierce',
+        name: '데이터 피어스',
+        description: '날카로운 데이터 창으로 방어를 무시하고 찌릅니다.',
+        power: 10,
+        type: 'attack',
+      },
+      {
+        id: 'restore-routine',
+        name: '리스토어 루틴',
+        description: '아군의 손상을 빠르게 복구합니다.',
+        power: 8,
+        type: 'heal',
+      },
+    ],
+  },
+  루크: {
+    name: '루크',
+    stats: {
+      maxHp: 140,
+      attack: 14,
+      defense: 12,
+      speed: 8,
+    },
+    skills: [
+      {
+        id: 'firewall-bash',
+        name: '파이어월 배시',
+        description: '강력한 방패로 적을 밀쳐 피해를 줍니다.',
+        power: 9,
+        type: 'attack',
+      },
+      {
+        id: 'system-recover',
+        name: '시스템 리커버리',
+        description: '방어막을 두르고 체력을 소량 회복합니다.',
+        power: 6,
+        type: 'heal',
+      },
+    ],
+  },
+};
+
+export const DEFAULT_PARTY = ['매튜'];
+
+export const getCharacterDefinition = (name: string): BattleCharacterDefinition =>
+  CHARACTER_LIBRARY[name] ?? {
+    name,
+    stats: {
+      maxHp: 90,
+      attack: 14,
+      defense: 8,
+      speed: 8,
+    },
+    skills: [defaultSkill],
+  };
+
+export const getPartyDefinitions = (names?: string[]) => {
+  const party = names && names.length > 0 ? names : DEFAULT_PARTY;
+  return party.map((member) => getCharacterDefinition(member));
+};

--- a/src/utils/novelTypes.ts
+++ b/src/utils/novelTypes.ts
@@ -31,6 +31,43 @@ export interface ChoiceNode {
 
 export type ChapterSentence = SentenceData | ChoiceNode;
 
+export interface BattleStats {
+  maxHp: number;
+  attack: number;
+  defense: number;
+  speed: number;
+}
+
+export type BattleSkillType = 'attack' | 'heal';
+
+export interface BattleSkill {
+  id: string;
+  name: string;
+  description: string;
+  power: number;
+  type: BattleSkillType;
+}
+
+export interface BattleCharacterDefinition {
+  name: string;
+  stats: BattleStats;
+  skills: BattleSkill[];
+}
+
+export interface BattleEnemyConfig {
+  name: string;
+  stats: BattleStats;
+  skills?: BattleSkill[];
+}
+
+export interface BattleConfig {
+  flag?: boolean;
+  description?: string;
+  encounter?: string;
+  enemy: BattleEnemyConfig;
+  party?: string[];
+}
+
 export interface Chapter {
   id?: string;
   changePosition?: true;
@@ -38,6 +75,7 @@ export interface Chapter {
   character: string;
   place: string;
   next?: ChoiceDestination;
+  battle?: BattleConfig;
 }
 
 export const isChoiceNode = (value: ChapterSentence | undefined): value is ChoiceNode => {

--- a/src/utils/useNovelEngine.ts
+++ b/src/utils/useNovelEngine.ts
@@ -2,6 +2,7 @@ import { CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
 import { getJson } from '#/getJson';
 import {
   Assets,
+  BattleConfig,
   Chapter,
   ChoiceDestination,
   ChoiceNode,
@@ -28,6 +29,7 @@ interface SceneState {
   next: ChoiceDestination | undefined;
   maxSentence: number;
   maxStep: number;
+  battle: BattleConfig | undefined;
 }
 
 const useNovelEngine = ({
@@ -52,6 +54,7 @@ const useNovelEngine = ({
     const scene = chapters[step[0]] ?? null;
     const sentence = scene?.sentences?.[step[1]];
     const sentenceData = isChoiceNode(sentence) ? undefined : (sentence as SentenceData | undefined);
+    const battle = scene?.battle && scene?.battle.flag !== false ? scene.battle : undefined;
     return {
       scene,
       sentence,
@@ -62,10 +65,11 @@ const useNovelEngine = ({
       next: scene?.next,
       maxSentence: scene?.sentences?.length ?? 0,
       maxStep: chapters.length,
+      battle,
     };
   }, [chapters, step]);
 
-  const { sentence, sentenceData, character, place, changePosition, next, maxSentence, maxStep } = sceneState;
+  const { sentence, sentenceData, character, place, changePosition, next, maxSentence, maxStep, battle } = sceneState;
 
   const assetList = useMemo(
     () => Object.values(assets).flatMap((x) => Object.values(x).filter((item) => Boolean(item)) as string[]),
@@ -170,6 +174,11 @@ const useNovelEngine = ({
     resetSceneProgress();
     advanceToNext();
   }, [activeChoice, advanceToNext, complete, handleComplete, resetSceneProgress]);
+
+  const forceNextScene = useCallback(() => {
+    resetSceneProgress();
+    advanceToNext();
+  }, [advanceToNext, resetSceneProgress]);
 
   const handleChoiceSelect = useCallback(
     (option: ChoiceOption) => {
@@ -321,6 +330,8 @@ const useNovelEngine = ({
     sentencePosition,
     activeChoice,
     complete,
+    battle,
+    forceNextScene,
   };
 };
 


### PR DESCRIPTION
## Summary
- add a turn-based battle screen that reads stat and skill data for each character and locks story input until the fight finishes
- extend the novel engine, storage, and routing with a game-over flow plus a new battle-enabled chapter in chapter0.json
- introduce shared battle data for party members and a dedicated game over page

## Testing
- pnpm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919bbc544608331ad70328bb6ec1af4)