### PR TITLE
Make launcher presentation fully data-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,18 @@ pnpm dev
 - `/`: YAVN 플레이그라운드(대표 게임 쇼케이스 + 검색/태그 게임 라이브러리 + ZIP 실행)
 - `/game-list/:gameId`: `public/game-list/<gameId>/` 게임 즉시 실행
 
-## 런처 메타데이터 (Manifest V3)
+## 데이터 처리 구조
+
+게임 실행 코드는 특정 작품이나 캐릭터를 알지 않습니다.
+
+1. URL 게임의 `config.yaml`, `base.yaml`, 챕터 YAML 또는 업로드한 ZIP의 YAML을 `src/parser.ts`가 읽습니다.
+2. YAML은 JavaScript 객체로 변환된 뒤 Zod 스키마와 참조 검증을 통과합니다.
+3. `src/engine.ts`가 검증된 공통 액션을 실행하고 `src/store.ts` 상태를 갱신합니다.
+4. `src/App.tsx`는 게임 ID가 아니라 배경, 캐릭터, 대사, 선택지, 스티커 같은 공통 상태만 렌더링합니다.
+
+루트 게임 목록만 빌드 시 생성된 JSON manifest를 사용합니다. 런타임 소스에 번들 샘플 ID나 샘플 전용 태그 분기가 들어오면 `src/gameIndependence.test.ts`가 실패합니다.
+
+## 런처 메타데이터 (Manifest V4)
 
 런처 게임 목록은 `predev`/`prebuild`에서 `scripts/generate-game-list-manifest.mjs`로 생성되며, 같은 단계에서 `public/sitemap.xml`도 게임 목록 기준으로 자동 재생성됩니다. 이후 `scripts/check-public-allowlist.mjs`로 `public` 허용 목록 검사를 수행합니다.
 
@@ -49,7 +60,7 @@ pnpm dev
 
 ```json
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "generatedAt": "2026-02-27T02:15:30.805Z",
   "games": [
     {
@@ -61,6 +72,14 @@ pnpm dev
       "summary": "가족 여행과 차 체험 뒤 2번 찻잔과 사라진 1분을 추적하는 캐릭터 중심 추리 에피소드",
       "thumbnail": "/game-list/conan/assets/bg/case_board.avif",
       "tags": ["detective", "sample"],
+      "showcase": {
+        "label": "FEATURED DEMO",
+        "image": {
+          "positionX": 50,
+          "positionY": 42,
+          "scale": 1.05
+        }
+      },
       "chapterCount": 10,
       "seo": {
         "title": "명탐정 코난 외전: 폭우의 2번 찻잔",
@@ -96,11 +115,21 @@ thumbnail: "assets/bg/cover.png"
 tags:
   - detective
   - live2d
+showcase:
+  label: "FEATURED DEMO"
+  backgroundColor: "#171b24"
+  image:
+    positionX: 50
+    positionY: 42
+    scale: 1.05
+    offsetX: 0
+    offsetY: 0
 ```
 
 - 이 파일은 런처 전용이며 엔진 DSL(`config/base/chapter`) 파서와 분리됩니다.
 - `thumbnail`은 상대 경로일 때 `/game-list/<gameId>/...`로 정규화됩니다.
 - `launcher.yaml.thumbnail`이 없고 `config.yaml.startScreen.image`가 있으면, manifest 생성 시 해당 이미지를 쇼케이스/게임 카드 기본 썸네일로 사용합니다.
+- `showcase`는 게임 ID나 태그에 의존하지 않고 캐러셀 문구와 썸네일 구도를 선언합니다. 위치는 `0..100`, 배율은 `0.5..2`, 오프셋은 `-50..50` 범위로 정규화됩니다.
 
 ## Public 최소화 정책
 
@@ -591,8 +620,9 @@ scenes:
 - 런처 첫 화면은 모든 플레이 가능한 데모를 실제 썸네일과 함께 보여주는 전체 폭 캐러셀입니다. 최초 진입은 데모를 무작위로 선택하고, 스와이프·마우스 드래그·좌우 화살표·키보드 방향키·페이지 인디케이터로 순환합니다.
 - 현재 캐러셀 데모는 `#demo=<gameId>` 해시에 기록되어 새로고침하거나 링크를 공유해도 같은 슬라이드를 엽니다. 아래 검색·태그 게임 목록은 상단 선택을 바꾸지 않으며 카드 전체를 누르면 해당 게임으로 바로 이동합니다.
 - 각 캐러셀 슬라이드는 독립된 페인트 경계 안에서 이미지와 콘텐츠를 자르며, 긴 제목·설명·태그는 화면 폭을 밀어내지 않습니다. 좁은 화면의 태그는 슬라이드 안에서만 가로 스크롤됩니다.
-- 게임 목록 manifest는 `schemaVersion: 3`를 사용하며 `author/version/summary/thumbnail/tags/chapterCount` + `seo` 메타를 포함합니다.
+- 게임 목록 manifest는 `schemaVersion: 4`를 사용하며 `author/version/summary/thumbnail/tags/showcase/chapterCount` + `seo` 메타를 포함합니다.
 - 런처 썸네일은 `launcher.yaml.thumbnail` 우선이며, 누락 시 `config.yaml.startScreen.image`를 기본값으로 사용합니다.
+- 캐러셀 라벨·배경색·썸네일 초점/배율/오프셋은 `launcher.yaml.showcase` 데이터만 사용하며 게임 ID나 `tags`를 조건으로 특별 처리하지 않습니다.
 - 런처는 V1(`id/name/path`) manifest도 fallback으로 지원합니다.
 - 게임별 `launcher.yaml`은 선택사항이며, 없으면 런처가 기본 요약/메타로 안전하게 렌더링합니다.
 - 런처/게임 페이지 SEO는 `config.yaml.seo`와 manifest 집계 `seo.gameTitles`를 사용해 `description/keywords/og/twitter/json-ld`를 동적으로 갱신합니다.

--- a/docs/DEVELOPMENT_GUIDE.ko.md
+++ b/docs/DEVELOPMENT_GUIDE.ko.md
@@ -13,13 +13,13 @@ pnpm dev
 - `/`: YAVN 플레이그라운드 (대표 게임 쇼케이스/게임 라이브러리/ZIP 실행)
 - `/game-list/:gameId`: `public/game-list/<gameId>/` 실행
 
-## 1-1) 런처 게임 목록 메타 (Manifest V3)
+## 1-1) 런처 게임 목록 메타 (Manifest V4)
 
 - `predev`/`prebuild`에서 `scripts/generate-game-list-manifest.mjs`를 실행해 `public/game-list/index.json` + `public/sitemap.xml`을 생성하고, 이어서 `scripts/check-public-allowlist.mjs`로 `public` 허용 목록을 검증합니다.
-- 최신 스키마는 `schemaVersion: 3`입니다.
+- 최신 스키마는 `schemaVersion: 4`입니다.
 - `games[]` 필드:
   - 기본: `id`, `name`, `path`
-  - 확장: `author`, `version`, `summary`, `thumbnail`, `tags`, `chapterCount`, `seo`
+  - 확장: `author`, `version`, `summary`, `thumbnail`, `tags`, `showcase`, `chapterCount`, `seo`
 - `seo` 루트 필드:
   - `title`, `description`, `keywords`, `gameTitles`, `gameCount`
 - `chapterCount`는 게임 폴더 하위 전체 YAML 중 `config/base/launcher`를 제외한 챕터 파일 수를 기록합니다.
@@ -29,11 +29,37 @@ pnpm dev
 
 선택 메타 파일:
 - `public/game-list/<gameId>/launcher.yaml` (선택)
-- 허용 키: `summary`, `thumbnail`, `tags`
+- 허용 키: `summary`, `thumbnail`, `tags`, `showcase`
 - 이 파일은 런처 전용이며 엔진 DSL 스키마(`config/base/chapter`)와 분리됩니다.
 - `launcher.yaml.thumbnail`이 없고 `config.yaml.startScreen.image`가 있으면 manifest 생성 시 해당 이미지를 기본 썸네일로 사용합니다.
+- `showcase.label`은 캐러셀 상단 라벨, `backgroundColor`는 3/4/6/8자리 hex 배경색입니다.
+- `showcase.image`는 `positionX/positionY(0..100)`, `scale(0.5..2)`, `offsetX/offsetY(-50..50)`를 지원하며 범위를 벗어난 숫자는 manifest 생성과 런타임 파싱에서 안전하게 보정됩니다.
 
-## 1-2) Public 허용 목록 정책
+예시:
+
+```yaml
+summary: "런처에 표시할 게임 설명"
+thumbnail: "assets/ui/launcher-preview.jpg"
+tags:
+  - interaction
+showcase:
+  label: "INTERACTION DEMO"
+  backgroundColor: "#171b24"
+  image:
+    positionX: 38
+    positionY: 35
+    scale: 1.08
+    offsetX: 18
+```
+
+## 1-2) 게임 독립성 원칙
+
+- URL 실행은 YAML을 `js-yaml`로 객체화한 뒤 `src/parser.ts`의 Zod 스키마/참조 검증, `src/engine.ts`의 공통 액션 실행, `src/store.ts`의 상태 갱신 순서로 처리합니다.
+- ZIP 실행도 파일 공급 방식만 다르고 같은 파서와 엔진을 사용합니다.
+- `src/App.tsx`는 게임 ID, 제목, 캐릭터명을 조건으로 렌더링하지 않습니다. 런처 구도도 `launcher.yaml -> index.json`의 `showcase` 데이터만 읽습니다.
+- `src/gameIndependence.test.ts`는 번들 샘플 ID와 과거 샘플 전용 태그/CSS 분기가 런타임에 다시 들어오는 것을 차단합니다.
+
+## 1-3) Public 허용 목록 정책
 
 - URL 게임 실행 호환을 위해 `public/game-list/**` 전체는 공개 경로로 유지합니다.
 - `public` 루트 허용 파일은 `favicon.svg`, `robots.txt`, `sitemap.xml`입니다.
@@ -355,6 +381,7 @@ scenes:
 - 인벤토리 모달의 `초기화면 가기` 버튼은 URL 게임에서만 활성화되며, 해당 `sessionStorage` 플래그를 지우고 현재 인게임 BGM을 즉시 정지한 뒤 Start Gate를 다시 표시합니다.
 - 런처 쇼케이스/게임 카드 썸네일 우선순위는 `launcher.yaml.thumbnail` -> `config.yaml.startScreen.image` 순서입니다.
 - 루트 런처는 manifest의 모든 게임을 전체 폭 데모 캐러셀로 렌더링합니다. 유효한 `#demo=<gameId>` 해시가 있으면 해당 게임을 열고, 해시가 없으면 최초 대표 데모를 무작위로 선택합니다.
+- 캐러셀의 라벨, 배경색, 썸네일 위치/배율/오프셋은 `launcher.yaml.showcase`에서 생성된 manifest 데이터로만 결정되며 게임 ID와 태그는 표현 분기에 사용하지 않습니다.
 - 스와이프·마우스 드래그·좌우 화살표·키보드 방향키·인디케이터 선택은 같은 캐러셀 상태와 URL 해시를 갱신합니다. 검색·태그 필터는 아래 직접 실행 목록에만 적용되며 상단 캐러셀 선택에는 영향을 주지 않습니다.
 - 각 캐러셀 슬라이드는 `layout/paint` 경계를 별도로 갖고 이미지·텍스트를 슬라이드 내부에서 클리핑합니다. 제목·요약·태그·게임 카드의 긴 문자열은 컨테이너 폭 안에서 줄바꿈되며, 좁은 화면의 태그 행만 내부 가로 스크롤을 허용합니다.
 - 시작 화면 타이틀/버튼(`시작하기`, `이어하기`)은 `config.yaml.ui.template` 전역 템플릿(`cinematic-noir` | `neon-grid` | `paper-stage`)을 그대로 적용합니다.
@@ -693,6 +720,7 @@ public/game-list/conan/
 
 ## 14) 문서 변경 로그
 
+- 2026-07-30: 런처가 `live2d`/`engine-showcase` 태그를 보고 이미지 구도와 라벨을 특별 처리하던 분기를 제거했습니다. Manifest V4의 범용 `showcase` 메타로 라벨·배경색·이미지 초점/배율/오프셋을 선언하며, 번들 샘플 ID와 전용 태그가 런타임에 다시 들어오면 독립성 테스트가 실패합니다.
 - 2026-07-30: 스티커·증거물의 좌표계를 HUD·다이얼로그·기기 safe-area를 제외한 공통 안전 프레임으로 변경했습니다. 실제 렌더 경계 기반의 균일 축소·최소 이동 보정을 추가해 짧은 가로 화면과 과대 에셋도 자르지 않으며, 모바일 다이얼로그에는 좌우·하단 최소 10px 외곽 여백을 추가했습니다.
 - 2026-07-30: 엔진 홈 캐러셀에서 320px 폭의 긴 태그 행이 슬라이드 너비를 밀어내고 음수 배경 레이어가 스와이프 중 이웃 에셋을 노출할 수 있던 문제를 수정했습니다. 슬라이드별 레이아웃·페인트 격리, 미디어 클리핑, 텍스트·카드 최대 폭 보호를 추가했습니다.
 - 2026-07-30: 새 이미지 캐릭터가 노출되거나 2인 구도로 전환될 때 수평 오프셋과 화자 확대가 하나의 `transform` 전환에 묶여 옆으로 슬라이드하던 문제를 수정했습니다. 수평 슬롯은 즉시 확정하고, 제자리 상승·페이드와 화자 `scale`만 독립적으로 애니메이션합니다.
@@ -703,7 +731,7 @@ public/game-list/conan/
 - 2026-07-30: 로컬 오디오 `music` 액션의 트랙 변경에 420ms 크로스페이드를 추가했습니다. 같은 곡은 재시작하지 않고, 음소거·초기화면 이동·명시적 정지는 즉시 반영되는 동작을 문서화했습니다. Conan 샘플은 v10 `폭우의 2번 찻잔`로 개편해 보유 BGM 7종을 도입/폭우/전조/사건/추리/압박/자백 큐로 분리했습니다.
 - 2026-07-30: 실제 노출 캐릭터가 정확히 두 명일 때 화면을 좌우 1/2 구도로 자동 전환하도록 캐릭터 레이아웃을 개선했습니다. 원래 슬롯 순서로 좌우를 고정해 화자 변경 시 자리 교환을 막고, 이미지/Live2D 및 모바일 폭을 각각 보정했으며 Conan 도입 대화에 적용했습니다.
 - 2026-07-29: `say.delivery` 감정형 타이핑 DSL을 추가했습니다. 8종 전달 톤, 캐릭터 표정 기반 자동 추론, 문장부호별 호흡, grapheme 단위 출력, 마지막 입력 글자 반응과 모션 감소 대응을 엔진에 연결하고 Conan 대사와 `sample.yaml` 예시를 갱신했습니다.
-- 2026-07-29: 메인 런처를 과밀한 3패널 Engine Console에서 실제 게임 이미지 중심의 YAVN 플레이그라운드로 재설계했습니다. 대표 게임 쇼케이스, 썸네일 라이브러리, 검색/태그, 카드별 바로 실행, ZIP 실행 툴바를 데스크톱·모바일 공통 흐름으로 구성하고 `engine-showcase` 태그 게임을 첫 대표작으로 선택합니다.
+- 2026-07-29: 메인 런처를 과밀한 3패널 Engine Console에서 실제 게임 이미지 중심의 YAVN 플레이그라운드로 재설계했습니다. 대표 게임 쇼케이스, 썸네일 라이브러리, 검색/태그, 카드별 바로 실행, ZIP 실행 툴바를 데스크톱·모바일 공통 흐름으로 구성했습니다.
 - 2026-07-29: 자동 진행형 쇼케이스를 위해 `say.autoAdvance`, `choice.timeoutMs`/`timeoutOptionIndex`, `root:/` 공유 에셋 경로와 `impact/glitch/speedlines/alarm/focus` 화면 이펙트를 추가했습니다. 이를 사용하는 독립 게임 `public/game-list/conan-demo`를 약 60초 분량의 모바일 대응 트레일러로 추가했습니다.
 - 2026-07-29: Conan 샘플의 설명조·판정조 대사를 전면 재작성했습니다. 용의자별 말투를 분리하고, `2번 잔 -> 21:29의 빈 시간 -> 손수건 섬유 -> 2R -> 연구 노트`가 잠자는 코고로의 폭로로 이어지도록 사건 인과를 보강했습니다. 코난과 혼동되던 용의자 `신이치`는 `세이지`로 변경했습니다.
 - 2026-07-29: `showTitle: false`인 Start Gate 이미지를 모바일 세로 화면에서 배경과 전경으로 분리해, `cover` 크롭으로 이미지 안의 게임 제목이 잘리던 문제를 수정했습니다. 소형 세로 화면과 모바일 가로 화면에서 제목/버튼 배치 및 페이지 오버플로를 검증했습니다.

--- a/public/game-list/conan-demo/launcher.yaml
+++ b/public/game-list/conan-demo/launcher.yaml
@@ -5,3 +5,5 @@ tags:
   - cinematic
   - engine-showcase
   - timed-choice
+showcase:
+  label: "ENGINE SHOWCASE"

--- a/public/game-list/index.json
+++ b/public/game-list/index.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 3,
-  "generatedAt": "2026-07-30T07:13:00.609Z",
+  "schemaVersion": 4,
+  "generatedAt": "2026-07-30T14:29:20.044Z",
   "games": [
     {
       "id": "conan",
@@ -52,6 +52,9 @@
         "engine-showcase",
         "timed-choice"
       ],
+      "showcase": {
+        "label": "ENGINE SHOWCASE"
+      },
       "chapterCount": 1,
       "seo": {
         "title": "명탐정 코난 DEMO: 60초의 경고",
@@ -83,6 +86,16 @@
         "interaction",
         "smoke-test"
       ],
+      "showcase": {
+        "label": "LIVE2D DEMO",
+        "backgroundColor": "#171b24",
+        "image": {
+          "positionX": 38,
+          "positionY": 35,
+          "scale": 1.08,
+          "offsetX": 18
+        }
+      },
       "chapterCount": 1,
       "seo": {
         "title": "Live2D 테스트: 렌 수다",

--- a/public/game-list/live2dtest/launcher.yaml
+++ b/public/game-list/live2dtest/launcher.yaml
@@ -4,3 +4,11 @@ tags:
   - live2d
   - interaction
   - smoke-test
+showcase:
+  label: "LIVE2D DEMO"
+  backgroundColor: "#171b24"
+  image:
+    positionX: 38
+    positionY: 35
+    scale: 1.08
+    offsetX: 18

--- a/scripts/generate-game-list-manifest.mjs
+++ b/scripts/generate-game-list-manifest.mjs
@@ -8,7 +8,7 @@ const gameListDir = path.join(workspaceRoot, 'public', 'game-list');
 const outputPath = path.join(gameListDir, 'index.json');
 const sitemapPath = path.join(publicDir, 'sitemap.xml');
 
-const MANIFEST_SCHEMA_VERSION = 3;
+const MANIFEST_SCHEMA_VERSION = 4;
 const MAX_LAUNCHER_SEO_TITLE_PREVIEW = 8;
 const DEFAULT_LAUNCHER_SEO_DESCRIPTION =
   '야븐엔진(YAVN)에서 플레이 가능한 비주얼노벨 게임 목록입니다.';
@@ -62,6 +62,43 @@ const normalizeTagList = (value) => {
     tags.push(normalized);
   }
   return tags;
+};
+
+const normalizeNumber = (value, min, max) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(max, Math.max(min, value));
+};
+
+const normalizeHexColor = (value) => {
+  const normalized = normalizeText(value);
+  return normalized && /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(normalized)
+    ? normalized
+    : undefined;
+};
+
+const normalizeLauncherShowcase = (value) => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const rawImage = isRecord(value.image) ? value.image : undefined;
+  const image = rawImage
+    ? {
+        positionX: normalizeNumber(rawImage.positionX, 0, 100),
+        positionY: normalizeNumber(rawImage.positionY, 0, 100),
+        scale: normalizeNumber(rawImage.scale, 0.5, 2),
+        offsetX: normalizeNumber(rawImage.offsetX, -50, 50),
+        offsetY: normalizeNumber(rawImage.offsetY, -50, 50),
+      }
+    : undefined;
+  const normalizedImage = image && Object.values(image).some((entry) => entry !== undefined) ? image : undefined;
+  const showcase = {
+    label: normalizeText(value.label)?.slice(0, 48),
+    backgroundColor: normalizeHexColor(value.backgroundColor),
+    image: normalizedImage,
+  };
+  return Object.values(showcase).some((entry) => entry !== undefined) ? showcase : undefined;
 };
 
 const mergeUniqueTextList = (...values) => {
@@ -206,6 +243,7 @@ async function resolveGameMetadata(gameDirPath, gameId, chapterYamlPaths) {
     summary: normalizeText(launcher?.summary),
     thumbnail: toGameAssetPath(gameId, launcherThumbnail ?? startScreenImage),
     tags: normalizeTagList(launcher?.tags),
+    showcase: normalizeLauncherShowcase(launcher?.showcase),
     chapterCount: chapterYamlPaths.length,
     seo: {
       title: resolvedName,
@@ -282,6 +320,7 @@ async function collectGameFolders() {
       summary: metadata.summary,
       thumbnail: metadata.thumbnail,
       tags: metadata.tags,
+      showcase: metadata.showcase,
       chapterCount: metadata.chapterCount,
       seo: metadata.seo,
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,11 @@ import {
   pickRandomCarouselIndex,
   wrapCarouselIndex,
 } from './launcherCarousel';
+import {
+  buildLauncherShowcaseStyle,
+  normalizeLauncherShowcase,
+  type LauncherShowcase,
+} from './launcherPresentation';
 import { buildLive2DLoadKey } from './live2dLoadTracker';
 import { fitStickerWithinFrame, type StickerFit } from './stickerLayout';
 import { useVNStore } from './store';
@@ -87,6 +92,7 @@ type GameListManifestEntry = {
   summary?: string;
   thumbnail?: string;
   tags: string[];
+  showcase?: LauncherShowcase;
   chapterCount?: number;
   seo?: GameListSeoEntry;
 };
@@ -451,6 +457,7 @@ function normalizeGameListEntry(value: unknown, index: number): GameListManifest
     summary: normalizeText(value.summary),
     thumbnail: normalizeText(value.thumbnail),
     tags: normalizeTags(value.tags),
+    showcase: normalizeLauncherShowcase(value.showcase),
     chapterCount: normalizeChapterCount(value.chapterCount),
     seo,
   };
@@ -2165,7 +2172,7 @@ export default function App() {
           <div className="launcher-runtime" aria-label="엔진 상태">
             <span className={`launcher-status launcher-status-${gameListStatus.toLowerCase()}`}>{gameListStatus}</span>
             <span>{gameList.length} PLAYABLE</span>
-            <span>DSL V{manifestSchemaVersion ?? 3}</span>
+            <span>DSL V{manifestSchemaVersion ?? 4}</span>
           </div>
 
           <nav className="launcher-nav" aria-label="엔진 링크">
@@ -2206,6 +2213,7 @@ export default function App() {
                     typeof entry.chapterCount === 'number'
                       ? `${entry.chapterCount} CHAPTER${entry.chapterCount === 1 ? '' : 'S'}`
                       : 'CHAPTERS -';
+                  const showcaseStyle = buildLauncherShowcaseStyle(entry.showcase) as CSSProperties | undefined;
                   return (
                     <article
                       key={`showcase-${entry.id}`}
@@ -2214,7 +2222,7 @@ export default function App() {
                       aria-roledescription="slide"
                       aria-label={`${index + 1} / ${gameList.length}: ${entry.name}`}
                     >
-                      <div className={`launcher-feature-media ${entry.tags.includes('live2d') ? 'is-live2d' : ''}`}>
+                      <div className="launcher-feature-media" style={showcaseStyle}>
                         {entry.thumbnail ? (
                           <img
                             src={entry.thumbnail}
@@ -2229,7 +2237,7 @@ export default function App() {
 
                       <div className="launcher-feature-copy">
                         <p className="launcher-feature-kicker">
-                          {entry.tags.includes('engine-showcase') ? 'ENGINE SHOWCASE' : 'PLAYABLE DEMO'}
+                          {entry.showcase?.label ?? 'PLAYABLE DEMO'}
                           <span>v{entry.version ?? '-'}</span>
                         </p>
                         <h2 id={`launcher-feature-title-${entry.id}`}>{entry.name}</h2>
@@ -2467,7 +2475,7 @@ export default function App() {
             <span>Type your story. Play your novel.</span>
           </p>
           <div>
-            <span>MANIFEST V{manifestSchemaVersion ?? 3}</span>
+            <span>MANIFEST V{manifestSchemaVersion ?? 4}</span>
             <span>SYNC {manifestTimestampLabel}</span>
             <a href={shareByPrUrl} target="_blank" rel="noreferrer">
               PR 보내기

--- a/src/gameIndependence.test.ts
+++ b/src/gameIndependence.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const runtimeFiles = [
+  'src/App.tsx',
+  'src/engine.ts',
+  'src/parser.ts',
+  'src/schema.ts',
+  'src/store.ts',
+  'src/styles.css',
+  'src/launcherPresentation.ts',
+  'scripts/generate-game-list-manifest.mjs',
+];
+
+const forbiddenSampleRules = [
+  { pattern: /\bconan\b/i, label: 'sample game id: conan' },
+  { pattern: /\bconan-demo\b/i, label: 'sample game id: conan-demo' },
+  { pattern: /\blive2dtest\b/i, label: 'sample game id: live2dtest' },
+  { pattern: /코난|코고로|미란/, label: 'sample character name' },
+  { pattern: /\bengine-showcase\b/i, label: 'sample tag: engine-showcase' },
+  { pattern: /\bis-live2d\b/i, label: 'sample-specific CSS class: is-live2d' },
+];
+
+describe('game-independent runtime', () => {
+  it('does not branch on bundled sample ids or presentation tags', () => {
+    for (const relativePath of runtimeFiles) {
+      const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
+      for (const rule of forbiddenSampleRules) {
+        expect(source, `${relativePath} contains ${rule.label}`).not.toMatch(rule.pattern);
+      }
+    }
+  });
+});

--- a/src/launcherPresentation.test.ts
+++ b/src/launcherPresentation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildLauncherShowcaseStyle, normalizeLauncherShowcase } from './launcherPresentation';
+
+describe('launcher showcase presentation', () => {
+  it('normalizes generic launcher metadata without inspecting game tags or ids', () => {
+    const showcase = normalizeLauncherShowcase({
+      label: '  ENGINE SHOWCASE  ',
+      backgroundColor: '#171b24',
+      image: {
+        positionX: 38,
+        positionY: 35,
+        scale: 1.08,
+        offsetX: 18,
+      },
+    });
+
+    expect(showcase).toEqual({
+      label: 'ENGINE SHOWCASE',
+      backgroundColor: '#171b24',
+      image: {
+        positionX: 38,
+        positionY: 35,
+        scale: 1.08,
+        offsetX: 18,
+        offsetY: undefined,
+      },
+    });
+    expect(buildLauncherShowcaseStyle(showcase)).toEqual({
+      '--launcher-showcase-background': '#171b24',
+      '--launcher-showcase-position-x': '38%',
+      '--launcher-showcase-position-y': '35%',
+      '--launcher-showcase-scale': '1.08',
+      '--launcher-showcase-offset-x': '18%',
+    });
+  });
+
+  it('clamps numeric input and rejects unsafe color values', () => {
+    expect(
+      normalizeLauncherShowcase({
+        backgroundColor: '#12345',
+        image: {
+          positionX: -20,
+          positionY: 140,
+          scale: 9,
+          offsetX: -80,
+          offsetY: 90,
+        },
+      }),
+    ).toEqual({
+      label: undefined,
+      backgroundColor: undefined,
+      image: {
+        positionX: 0,
+        positionY: 100,
+        scale: 2,
+        offsetX: -50,
+        offsetY: 50,
+      },
+    });
+  });
+
+  it('returns undefined when no supported presentation value exists', () => {
+    expect(normalizeLauncherShowcase({ image: { scale: 'large' } })).toBeUndefined();
+    expect(buildLauncherShowcaseStyle(undefined)).toBeUndefined();
+  });
+});

--- a/src/launcherPresentation.ts
+++ b/src/launcherPresentation.ts
@@ -1,0 +1,93 @@
+export type LauncherShowcaseImage = {
+  positionX?: number;
+  positionY?: number;
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
+};
+
+export type LauncherShowcase = {
+  label?: string;
+  backgroundColor?: string;
+  image?: LauncherShowcaseImage;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const normalizeText = (value: unknown, maxLength: number): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.slice(0, maxLength);
+};
+
+const normalizeNumber = (value: unknown, min: number, max: number): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(max, Math.max(min, value));
+};
+
+const normalizeHexColor = (value: unknown): string | undefined => {
+  const normalized = normalizeText(value, 9);
+  return normalized && /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(normalized)
+    ? normalized
+    : undefined;
+};
+
+export function normalizeLauncherShowcase(value: unknown): LauncherShowcase | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const rawImage = isRecord(value.image) ? value.image : undefined;
+  const image: LauncherShowcaseImage | undefined = rawImage
+    ? {
+        positionX: normalizeNumber(rawImage.positionX, 0, 100),
+        positionY: normalizeNumber(rawImage.positionY, 0, 100),
+        scale: normalizeNumber(rawImage.scale, 0.5, 2),
+        offsetX: normalizeNumber(rawImage.offsetX, -50, 50),
+        offsetY: normalizeNumber(rawImage.offsetY, -50, 50),
+      }
+    : undefined;
+  const normalizedImage = image && Object.values(image).some((entry) => entry !== undefined) ? image : undefined;
+  const showcase: LauncherShowcase = {
+    label: normalizeText(value.label, 48),
+    backgroundColor: normalizeHexColor(value.backgroundColor),
+    image: normalizedImage,
+  };
+
+  return Object.values(showcase).some((entry) => entry !== undefined) ? showcase : undefined;
+}
+
+export function buildLauncherShowcaseStyle(showcase: LauncherShowcase | undefined): Record<string, string> | undefined {
+  if (!showcase) {
+    return undefined;
+  }
+
+  const style: Record<string, string> = {};
+  if (showcase.backgroundColor) {
+    style['--launcher-showcase-background'] = showcase.backgroundColor;
+  }
+  if (showcase.image?.positionX !== undefined) {
+    style['--launcher-showcase-position-x'] = `${showcase.image.positionX}%`;
+  }
+  if (showcase.image?.positionY !== undefined) {
+    style['--launcher-showcase-position-y'] = `${showcase.image.positionY}%`;
+  }
+  if (showcase.image?.scale !== undefined) {
+    style['--launcher-showcase-scale'] = String(showcase.image.scale);
+  }
+  if (showcase.image?.offsetX !== undefined) {
+    style['--launcher-showcase-offset-x'] = `${showcase.image.offsetX}%`;
+  }
+  if (showcase.image?.offsetY !== undefined) {
+    style['--launcher-showcase-offset-y'] = `${showcase.image.offsetY}%`;
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3450,7 +3450,7 @@ textarea,
   max-height: 100%;
   overflow: hidden;
   overflow: clip;
-  background: #202329;
+  background: var(--launcher-showcase-background, #202329);
 }
 
 .launcher-feature-media::after {
@@ -3471,16 +3471,15 @@ textarea,
   max-height: 100%;
   display: block;
   object-fit: cover;
-  object-position: center;
-}
-
-.launcher-feature-media.is-live2d {
-  background: #171b24;
-}
-
-.launcher-feature-media.is-live2d img {
-  object-position: 38% 35%;
-  transform: scale(1.08) translateX(18%);
+  object-position:
+    var(--launcher-showcase-position-x, 50%)
+    var(--launcher-showcase-position-y, 50%);
+  transform:
+    translate(
+      var(--launcher-showcase-offset-x, 0%),
+      var(--launcher-showcase-offset-y, 0%)
+    )
+    scale(var(--launcher-showcase-scale, 1));
   transform-origin: center;
 }
 


### PR DESCRIPTION
## 변경 내용
- 런처의 `live2d` / `engine-showcase` 태그 기반 특별 처리를 제거했습니다.
- Manifest V4 `showcase` 메타로 라벨, 배경색, 썸네일 초점·배율·오프셋을 공통 처리합니다.
- 코난 데모와 Live2D 데모의 기존 표현을 `launcher.yaml` 데이터로 이전했습니다.
- 샘플 게임 ID·캐릭터명·전용 태그가 런타임 코드에 들어오면 실패하는 독립성 회귀 테스트를 추가했습니다.
- README와 개발 가이드에 YAML 파싱부터 공통 엔진 렌더링까지의 데이터 흐름을 문서화했습니다.

## 이유
엔진과 런처가 개별 게임 이름이나 태그를 알아야 하는 구조를 없애고, 새 게임도 코드 수정 없이 선언 데이터만으로 동일한 표현 기능을 쓰도록 하기 위해서입니다.

## 검증
- Vitest 54개 통과
- TypeScript 빌드 검사 통과
- public allowlist 119개 통과
- Vite production build 통과
- 1440x900 / 390x844 실브라우저 검증: 가로 오버플로 0, 콘솔 오류 0