### PR TITLE
Update GitHub Actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: corepack enable


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` from v4 to v7.
- Upgrade `actions/setup-node` from v4 to v7.

## Why

The successful post-merge CI run emitted deprecation annotations because both v4 actions target the retired Node 20 action runtime. The current v7 releases use the supported runtime and remove those warnings while keeping the project test matrix on Node 22.

## Validation

- Confirmed latest official releases through the GitHub API: `actions/checkout@v7.0.1`, `actions/setup-node@v7.0.0`.
- The workflow itself will validate checkout, Node 22 setup, pnpm 11.21 install, all tests, and the production build.
